### PR TITLE
Add unit-test structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-*.bin
+# Build artifacts.
+build/
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/CMock"]
+	path = test/CMock
+	url = git@github.com:ThrowTheSwitch/CMock.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "test/CMock"]
 	path = test/CMock
 	url = git@github.com:ThrowTheSwitch/CMock.git
-	
+	update = none

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "test/CMock"]
 	path = test/CMock
 	url = git@github.com:ThrowTheSwitch/CMock.git
+	

--- a/README.md
+++ b/README.md
@@ -71,7 +71,58 @@ port allocated to it by NAT.
 4. Repeat step 2 and 3 till `StunDeserializer_GetNextAttribute()` returns
    `STUN_RESULT_NO_MORE_ATTRIBUTE_FOUND`.
 
+## Building Unit Tests
+
+### Platform Prerequisites
+- For running unit tests:
+    - C99 compiler like gcc.
+    - CMake 3.13.0 or later.
+    - Ruby 2.0.0 or later (It is required for the CMock test framework that we
+      use).
+- For running the coverage target, gcov and lcov are required.
+
+### Checkout CMock Submodule
+By default, the submodules in this repository are configured with `update=none`
+in [.gitmodules](./.gitmodules) to avoid increasing clone time and disk space
+usage of other repositories.
+
+To build unit tests, the submodule dependency of CMock is required. Use the
+following command to clone the submodule:
+
+```sh
+git submodule update --checkout --init --recursive test/CMock
+```
+
+### Steps to build Unit Tests
+1. Go to the root directory of this repository. (Make sure that the CMock
+   submodule is cloned as described in [Checkout CMock Submodule](#checkout-cmock-submodule)).
+1. Run the following command to generate Makefiles:
+
+    ```sh
+    cmake -S test/unit-test -B build/ -G "Unix Makefiles" \
+     -DCMAKE_BUILD_TYPE=Debug \
+     -DBUILD_CLONE_SUBMODULES=ON \
+     -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+    ```
+1. Run the following command to build the library and unit tests:
+
+    ```sh
+    make -C build all
+    ```
+1. Run the following command to execute all tests and view results:
+
+    ```sh
+    cd build && ctest -E system --output-on-failure
+    ```
+
+### Steps to generate code coverage report of Unit Test
+1. Run Unit Tests in [Steps to build Unit Tests](#steps-to-build-unit-tests).
+1. Generate coverage report in 'build/coverage' folder:
+
+    ```
+    make coverage
+    ```
+
 ## License
 
 This project is licensed under the Apache-2.0 License.
-

--- a/source/include/stun_deserializer.h
+++ b/source/include/stun_deserializer.h
@@ -60,8 +60,7 @@ StunResult_t StunDeserializer_FindAttribute( StunContext_t * pCtx,
                                              StunAttributeType_t attributeType,
                                              StunAttribute_t * pAttribute );
 
-StunResult_t StunDeserializer_UpdateAttributeNonce( const StunContext_t * pCtx,
-                                                    const char * pNonce,
+StunResult_t StunDeserializer_UpdateAttributeNonce( const uint8_t * pNonce,
                                                     uint16_t nonceLength,
                                                     StunAttribute_t * pAttribute );
 

--- a/source/stun_deserializer.c
+++ b/source/stun_deserializer.c
@@ -128,7 +128,7 @@ StunResult_t StunDeserializer_Init( StunContext_t * pCtx,
         {
             result = STUN_RESULT_MAGIC_COOKIE_MISMATCH;
         }
-        else if( ( messageLengthInHeader + STUN_HEADER_LENGTH ) != stunMessageLength )
+        else if( ( ( size_t ) messageLengthInHeader + STUN_HEADER_LENGTH ) != stunMessageLength )
         {
             result = STUN_RESULT_INVALID_MESSAGE_LENGTH;
         }
@@ -201,7 +201,7 @@ StunResult_t StunDeserializer_GetNextAttribute( StunContext_t * pCtx,
                                                                               STUN_ATTRIBUTE_HEADER_LENGTH_OFFSET ] ) );
 
         /* Check that we have enough data to read attribute value. */
-        if( STUN_REMAINING_LENGTH( pCtx ) < STUN_ATTRIBUTE_TOTAL_LENGTH( pAttribute->attributeValueLength ) )
+        if( STUN_REMAINING_LENGTH( pCtx ) < ( size_t ) STUN_ATTRIBUTE_TOTAL_LENGTH( pAttribute->attributeValueLength ) )
         {
             result = STUN_RESULT_OUT_OF_MEMORY;
         }
@@ -534,15 +534,13 @@ StunResult_t StunDeserializer_FindAttribute( StunContext_t * pCtx,
 
 /*-----------------------------------------------------------*/
 
-StunResult_t StunDeserializer_UpdateAttributeNonce( const StunContext_t * pCtx,
-                                                    const char * pNonce,
+StunResult_t StunDeserializer_UpdateAttributeNonce( const uint8_t * pNonce,
                                                     uint16_t nonceLength,
                                                     StunAttribute_t * pAttribute )
 {
     StunResult_t result = STUN_RESULT_OK;
 
-    if( ( pCtx == NULL ) ||
-        ( pAttribute == NULL ) ||
+    if( ( pAttribute == NULL ) ||
         ( pNonce == NULL ) ||
         ( pAttribute->attributeType != STUN_ATTRIBUTE_TYPE_NONCE ) ||
         ( pAttribute->attributeValueLength != nonceLength ) )

--- a/source/stun_deserializer.c
+++ b/source/stun_deserializer.c
@@ -250,7 +250,8 @@ StunResult_t StunDeserializer_ParseAttributeErrorCode( const StunAttribute_t * p
         errorClass = pAttribute->pAttributeValue[ STUN_ATTRIBUTE_ERROR_CODE_CLASS_OFFSET ];
         errorNumber = pAttribute->pAttributeValue[ STUN_ATTRIBUTE_ERROR_CODE_NUMBER_OFFSET ];
 
-        *pErrorCode = STUN_GET_ERROR( errorClass, errorNumber );
+        *pErrorCode = STUN_GET_ERROR( errorClass,
+                                      errorNumber );
         *ppErrorPhrase = &( pAttribute->pAttributeValue[ STUN_ATTRIBUTE_ERROR_CODE_REASON_PHRASE_OFFSET ] );
         *pErrorPhraseLength = errorPhaseLength;
     }
@@ -408,7 +409,8 @@ StunResult_t StunDeserializer_ParseAttributeAddress( const StunContext_t * pCtx,
             /* XOR first 4 bytes of IP address with magic cookie. */
             word = STUN_READ_UINT32( &( pAddress->address[ 0 ] ) );
             xorWord = word ^ STUN_HEADER_MAGIC_COOKIE;
-            STUN_WRITE_UINT32( &( pAddress->address[ 0 ] ), xorWord );
+            STUN_WRITE_UINT32( &( pAddress->address[ 0 ] ),
+                               xorWord );
 
             if( pAddress->family == STUN_ADDRESS_IPv6 )
             {
@@ -539,7 +541,8 @@ StunResult_t StunDeserializer_UpdateAttributeNonce( const StunContext_t * pCtx,
 {
     StunResult_t result = STUN_RESULT_OK;
 
-    if( ( pAttribute == NULL ) ||
+    if( ( pCtx == NULL ) ||
+        ( pAttribute == NULL ) ||
         ( pNonce == NULL ) ||
         ( pAttribute->attributeType != STUN_ATTRIBUTE_TYPE_NONCE ) ||
         ( pAttribute->attributeValueLength != nonceLength ) )

--- a/source/stun_serializer.c
+++ b/source/stun_serializer.c
@@ -95,7 +95,7 @@ static StunResult_t AddAttributeBuffer( StunContext_t * pCtx,
     if( ( result == STUN_RESULT_OK ) &&
         ( pCtx->pStart != NULL ) )
     {
-        if( STUN_REMAINING_LENGTH( pCtx ) < STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLengthPadded ) )
+        if( STUN_REMAINING_LENGTH( pCtx ) < ( size_t ) STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLengthPadded ) )
         {
             result = STUN_RESULT_OUT_OF_MEMORY;
         }
@@ -154,7 +154,7 @@ static StunResult_t AddAttributeTypeOnly( StunContext_t * pCtx,
     if( ( result == STUN_RESULT_OK ) &&
         ( pCtx->pStart != NULL ) )
     {
-        if( STUN_REMAINING_LENGTH( pCtx ) < STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLength ) )
+        if( STUN_REMAINING_LENGTH( pCtx ) < ( size_t ) STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLength ) )
         {
             result = STUN_RESULT_OUT_OF_MEMORY;
         }
@@ -201,7 +201,7 @@ static StunResult_t AddAttributeUint32( StunContext_t * pCtx,
     if( ( result == STUN_RESULT_OK ) &&
         ( pCtx->pStart != NULL ) )
     {
-        if( STUN_REMAINING_LENGTH( pCtx ) < STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLength ) )
+        if( STUN_REMAINING_LENGTH( pCtx ) < ( size_t ) STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLength ) )
         {
             result = STUN_RESULT_OUT_OF_MEMORY;
         }
@@ -251,7 +251,7 @@ static StunResult_t AddAttributeUint64( StunContext_t * pCtx,
     if( ( result == STUN_RESULT_OK ) &&
         ( pCtx->pStart != NULL ) )
     {
-        if( STUN_REMAINING_LENGTH( pCtx ) < STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLength ) )
+        if( STUN_REMAINING_LENGTH( pCtx ) < ( size_t ) STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLength ) )
         {
             result = STUN_RESULT_OUT_OF_MEMORY;
         }
@@ -394,7 +394,7 @@ StunResult_t StunSerializer_AddAttributeErrorCode( StunContext_t * pCtx,
     if( ( result == STUN_RESULT_OK ) &&
         ( pCtx->pStart != NULL ) )
     {
-        if( STUN_REMAINING_LENGTH( pCtx ) < STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLengthPadded ) )
+        if( STUN_REMAINING_LENGTH( pCtx ) < ( size_t ) STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLengthPadded ) )
         {
             result = STUN_RESULT_OUT_OF_MEMORY;
         }
@@ -465,7 +465,7 @@ StunResult_t StunSerializer_AddAttributeChannelNumber( StunContext_t * pCtx,
     if( ( result == STUN_RESULT_OK ) &&
         ( pCtx->pStart != NULL ) )
     {
-        if( STUN_REMAINING_LENGTH( pCtx ) < STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLength ) )
+        if( STUN_REMAINING_LENGTH( pCtx ) < ( size_t ) STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLength ) )
         {
             result = STUN_RESULT_OUT_OF_MEMORY;
         }
@@ -674,7 +674,7 @@ StunResult_t StunSerializer_AddAttributeAddress( StunContext_t * pCtx,
     if( ( result == STUN_RESULT_OK ) &&
         ( pCtx->pStart != NULL ) )
     {
-        if( STUN_REMAINING_LENGTH( pCtx ) < STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLength ) )
+        if( STUN_REMAINING_LENGTH( pCtx ) < ( size_t ) STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLength ) )
         {
             result = STUN_RESULT_OUT_OF_MEMORY;
         }

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -1,0 +1,100 @@
+# Set the required version.
+cmake_minimum_required( VERSION 3.13.0 )
+
+# Set the unit-test project.
+project( "STUN unit test"
+         VERSION 1.0.0
+         LANGUAGES C )
+
+# Allow the project to be organized into folders.
+set_property( GLOBAL PROPERTY USE_FOLDERS ON )
+
+# Use C99.
+set( CMAKE_C_STANDARD 99 )
+set( CMAKE_C_STANDARD_REQUIRED ON )
+
+# Do not allow in-source build.
+if( ${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR} )
+    message( FATAL_ERROR "In-source build is not allowed. Please build in a separate directory, such as ${PROJECT_SOURCE_DIR}/build." )
+endif()
+
+# Set global path variables.
+get_filename_component( __MODULE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE )
+set( MODULE_ROOT_DIR ${__MODULE_ROOT_DIR} CACHE INTERNAL "STUN repository root." )
+
+# Set the unit-test directory.
+set( UNIT_TEST_DIR ${MODULE_ROOT_DIR}/test/unit-test CACHE INTERNAL "Unit-test directory." )
+
+# Set the include directories.
+string( APPEND GLOBAL_INCLUDES "-I ${MODULE_ROOT_DIR}/source/include")
+
+# Configure options to always show in CMake GUI.
+option( BUILD_CLONE_SUBMODULES
+        "Set this to ON to automatically clone any required Git submodules. When OFF, submodules must be manually cloned."
+        ON )
+
+# Set output directories.
+set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
+set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
+set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
+
+# ===================================== Include the cmake configurations =================================================
+message( STATUS ${CMAKE_BINARY_DIR} )
+
+# Include filepaths for source and include.
+include( ${MODULE_ROOT_DIR}/stunFilePaths.cmake )
+
+# Target for Coverity analysis that builds the library.
+add_library( coverity_analysis
+             ${STUN_SOURCES}
+             ${STUN_INCLUDE_PUBLIC_DIRS}
+             ${MODULE_ROOT_DIR}/test/unit-test )
+
+target_compile_definitions( coverity_analysis PUBLIC NDEBUG=1 )
+
+#STUN public include path.
+target_include_directories( coverity_analysis PUBLIC ${STUN_INCLUDE_PUBLIC_DIRS} ${MODULE_ROOT_DIR}/test/unit-test )
+
+# ========================= Test Configuration ==============================
+# Define a CMock resource path.
+set( CMOCK_DIR ${MODULE_ROOT_DIR}/test/CMock CACHE INTERNAL "CMock library source directory." )
+
+# Include CMock build configuration.
+include( cmock_build.cmake )
+
+# Check if the CMock source directory exists, and if not present, clone the submodule
+# if BUILD_CLONE_SUBMODULES configuration is enabled.
+if( NOT EXISTS ${CMOCK_DIR}/source )
+    # Attempt to clone CMock.
+    if( ${BUILD_CLONE_SUBMODULES} )
+        clone_cmock()
+    else()
+        message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 'ON' to automatically clone it during build." )
+    endif()
+endif()
+
+# Use CTest utility for managing test runs. This has to be added BEFORE
+# defining test targets with add_test()
+enable_testing()
+
+# Add build targets for CMock and Unit, required for unit testing.
+add_cmock_targets()
+
+# Add function to enable CMock based tests and coverage.
+include( ${MODULE_ROOT_DIR}/test/unit-test/cmock/create_test.cmake )
+
+# Include unit-test build configuration.
+include( ${UNIT_TEST_DIR}/stun_serializer/ut.cmake )
+include( ${UNIT_TEST_DIR}/stun_deserializer/ut.cmake )
+
+#  ==================================== Coverage Analysis configuration ========================================
+# Add a target for running coverage on tests.
+add_custom_target( coverage
+    COMMAND ${CMAKE_COMMAND} -DCMOCK_DIR=${CMOCK_DIR}
+    -P ${MODULE_ROOT_DIR}/test/unit-test/cmock/coverage.cmake
+    DEPENDS cmock unity
+    stun_serializer
+    stun_deserializer
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -93,8 +93,8 @@ add_custom_target( coverage
     COMMAND ${CMAKE_COMMAND} -DCMOCK_DIR=${CMOCK_DIR}
     -P ${MODULE_ROOT_DIR}/test/unit-test/cmock/coverage.cmake
     DEPENDS cmock unity
-    stun_serializer
-    stun_deserializer
+    stun_serializer_utest
+    stun_deserializer_utest
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 

--- a/test/unit-test/README.md
+++ b/test/unit-test/README.md
@@ -40,7 +40,7 @@ the following script:
 
 ```sh
 #!/bin/bash
-# This script should be run from the root directory of the amazon-kinesis-video-streams-stun
+# This script should be run from the root directory of the amazon-kinesis-video-streams-stun.
  repo.
 
 if [[ ! -d source ]]; then
@@ -52,31 +52,18 @@ fi
 UNIT_TEST_DIR="test/unit-test"
 BUILD_DIR="${UNIT_TEST_DIR}/build"
 
-# Create the build directory using CMake:
+# Create the build directory using CMake.
 rm -rf ${BUILD_DIR}/
 cmake -S ${UNIT_TEST_DIR} -B ${BUILD_DIR}/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
 
-# Create the executables:
+# Create the executables.
 make -C ${BUILD_DIR}/ all
 
 pushd ${BUILD_DIR}/
-# Run the tests for all units
+# Run the tests for all units.
 ctest -E system --output-on-failure
 popd
 
-# Calculate the coverage
+# Calculate the coverage.
 make -C ${BUILD_DIR}/ coverage
-```
-
-You should see an output similar to this:
-
-```
-test_H264_Packetizer_AddNalu             PASS
-test_H264_Packetizer_AddFrame            PASS
-
-=================== SUMMARY =====================
-
-Tests Passed  : 16
-Tests Failed  : 0
-Tests Ignored : 0
 ```

--- a/test/unit-test/README.md
+++ b/test/unit-test/README.md
@@ -1,0 +1,82 @@
+# Unit Tests for amazon-kinesis-video-streams-stun library
+
+This directory contains unit tests for amazon-kinesis-video-streams-stun library.
+It submodules the [CMock](https://github.com/ThrowTheSwitch/CMock) framework
+(which submodules [Unity](https://github.com/throwtheswitch/unity/)).
+
+## Getting Started
+
+### Prerequisites
+
+You can run these tests on any GNU Make compatible system. To build and run
+these tests, you must have the following:
+
+1. Make (You can check whether you have this by typing `make --version`).
+   - Not found? Try `apt-get install make`.
+1. Ruby (You can check whether you have this by typing `ruby --version`).
+   - Not found? Try `apt-get install ruby`.
+1. CMake version > 3.13.0 (You can check whether you have this by typing
+   `cmake --version`).
+   - Not found? Try `apt-get install cmake`.
+   - Run the `cmake --version` command. If still the version number is >=
+     3.13.0, skip to (4.) or else, continue.
+   - You will need to get the latest CMake version using curl or wget (or
+     similar command).
+     - Uninstall the current version of CMake using
+       `sudo apt remove --purge --auto-remove cmake`.
+     - Download the [CMAKE version 3.13.0](https://cmake.org/files/v3.13/).
+     - Extract the cmake download using `tar -xzvf cmake-3.13.0.tar.gz`.
+     - Go to the extracted folder (`cd cmake-3.13.0`) and run `./bootstrap`.
+     - Run `make -j$(nproc)` and then run `sudo make install`.
+     - Check the version using `cmake --version` command.
+1. lcov version 1.14 (You can check whether you have this by typing
+   `lcov --version`).
+     - Not found? Try `sudo apt-get install lcov`
+
+### To run the Unit tests:
+
+Go to the root directory of the amazon-kinesis-video-streams-stun repo and run
+the following script:
+
+```sh
+#!/bin/bash
+# This script should be run from the root directory of the amazon-kinesis-video-streams-stun
+ repo.
+
+if [[ ! -d source ]]; then
+    echo "Please run this script from the root directory of the amazon-kinesis-video-streams-stun
+     repo."
+    exit 1
+fi
+
+UNIT_TEST_DIR="test/unit-test"
+BUILD_DIR="${UNIT_TEST_DIR}/build"
+
+# Create the build directory using CMake:
+rm -rf ${BUILD_DIR}/
+cmake -S ${UNIT_TEST_DIR} -B ${BUILD_DIR}/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
+
+# Create the executables:
+make -C ${BUILD_DIR}/ all
+
+pushd ${BUILD_DIR}/
+# Run the tests for all units
+ctest -E system --output-on-failure
+popd
+
+# Calculate the coverage
+make -C ${BUILD_DIR}/ coverage
+```
+
+You should see an output similar to this:
+
+```
+test_H264_Packetizer_AddNalu             PASS
+test_H264_Packetizer_AddFrame            PASS
+
+=================== SUMMARY =====================
+
+Tests Passed  : 16
+Tests Failed  : 0
+Tests Ignored : 0
+```

--- a/test/unit-test/catch_assert.h
+++ b/test/unit-test/catch_assert.h
@@ -1,0 +1,57 @@
+/*
+ * How to catch an assert:
+ * - save a jump buffer where execution will resume after the assert
+ * - setup a handler for the abort signal, call longjmp within
+ * - optional - close stderr ( fd 2 ) to discard the assert message
+ *
+ * Unity also does a longjmp within its TEST_ASSERT* macros,
+ * so the macro below restores stderr and the prior abort handler
+ * before calling the Unity macro.
+ */
+
+#ifndef CATCH_ASSERT_H_
+#define CATCH_ASSERT_H_
+
+#include <setjmp.h>
+#include <signal.h>
+#include <unistd.h>
+
+#ifndef CATCH_JMPBUF
+    #define CATCH_JMPBUF    waypoint_
+#endif
+
+static jmp_buf CATCH_JMPBUF;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+static void catchHandler_( int signal )
+{
+    longjmp( CATCH_JMPBUF, signal );
+}
+#pragma GCC diagnostic pop
+
+#define catch_assert( x )                    \
+    do {                                     \
+        int ltry = 0, lcatch = 0;            \
+        int saveFd = dup( 2 );               \
+        struct sigaction sa = { 0 }, saveSa; \
+        sa.sa_handler = catchHandler_;       \
+        sigaction( SIGABRT, &sa, &saveSa );  \
+        close( 2 );                          \
+        if( setjmp( CATCH_JMPBUF ) == 0 )    \
+        {                                    \
+            ltry++;                          \
+            x;                               \
+        }                                    \
+        else                                 \
+        {                                    \
+            lcatch++;                        \
+        }                                    \
+        sigaction( SIGABRT, &saveSa, NULL ); \
+        dup2( saveFd, 2 );                   \
+        close( saveFd );                     \
+        TEST_ASSERT_EQUAL( ltry, lcatch );   \
+    } while( 0 )
+
+#endif /* ifndef CATCH_ASSERT_H_ */
+

--- a/test/unit-test/cmock/coverage.cmake
+++ b/test/unit-test/cmock/coverage.cmake
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 3.13)
+set(BINARY_DIR ${CMAKE_BINARY_DIR})
+
+# Reset coverage counters.
+execute_process(
+            COMMAND lcov --directory ${CMAKE_BINARY_DIR}
+                         --base-directory ${CMAKE_BINARY_DIR}
+                         --zerocounters
+
+            COMMAND mkdir -p  ${CMAKE_BINARY_DIR}/coverage
+        )
+
+# Make the initial/baseline capture a zeroed out files.
+execute_process( COMMAND lcov --directory ${CMAKE_BINARY_DIR}
+                         --base-directory ${CMAKE_BINARY_DIR}
+                         --initial
+                         --capture
+                         --rc lcov_branch_coverage=1
+                         --output-file=${CMAKE_BINARY_DIR}/base_coverage.info
+                         --include "*source*"
+        )
+file(GLOB files "${CMAKE_BINARY_DIR}/bin/tests/*")
+
+set(REPORT_FILE ${CMAKE_BINARY_DIR}/utest_report.txt)
+file(WRITE ${REPORT_FILE} "")
+
+# Execute all files in bin directory, gathering the output to show it in CI.
+foreach(testname ${files})
+    get_filename_component(test
+                           ${testname}
+                           NAME_WLE
+            )
+    message("Running ${testname}")
+    execute_process(COMMAND ${testname} OUTPUT_FILE ${CMAKE_BINARY_DIR}/${test}_out.txt)
+
+    file(READ ${CMAKE_BINARY_DIR}/${test}_out.txt CONTENTS)
+    file(APPEND ${REPORT_FILE} "${CONTENTS}")
+endforeach()
+
+# Generate Junit style xml output.
+execute_process(COMMAND ruby
+    ${CMOCK_DIR}/vendor/unity/auto/parse_output.rb
+                    -xml ${REPORT_FILE}
+                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            )
+
+# Capture data after running the tests.
+execute_process(
+            COMMAND lcov --capture
+                         --rc lcov_branch_coverage=1
+                         --base-directory ${CMAKE_BINARY_DIR}
+                         --directory ${CMAKE_BINARY_DIR}
+                         --output-file ${CMAKE_BINARY_DIR}/second_coverage.info
+                         --include "*source*"
+        )
+
+# Combile baseline results (zeros) with the one after running the tests.
+execute_process(
+            COMMAND lcov --base-directory ${CMAKE_BINARY_DIR}
+                         --directory ${CMAKE_BINARY_DIR}
+                         --add-tracefile ${CMAKE_BINARY_DIR}/base_coverage.info
+                         --add-tracefile ${CMAKE_BINARY_DIR}/second_coverage.info
+                         --output-file ${CMAKE_BINARY_DIR}/coverage.info
+                         --rc lcov_branch_coverage=1
+                         --include "*source*"
+        )
+execute_process(
+            COMMAND genhtml --rc lcov_branch_coverage=1
+                            --branch-coverage
+                            --output-directory ${CMAKE_BINARY_DIR}/coverage
+                            ${CMAKE_BINARY_DIR}/coverage.info
+        )

--- a/test/unit-test/cmock/create_test.cmake
+++ b/test/unit-test/cmock/create_test.cmake
@@ -1,0 +1,172 @@
+# Function to create the test executable.
+function(create_test test_name
+                     test_src
+                     link_list
+                     dep_list
+                     include_list)
+    set(mocks_dir "${CMAKE_CURRENT_BINARY_DIR}/mocks")
+    include (CTest)
+    get_filename_component(test_src_absolute ${test_src} ABSOLUTE)
+    add_custom_command(OUTPUT ${test_name}_runner.c
+                  COMMAND ruby
+                    ${CMOCK_DIR}/vendor/unity/auto/generate_test_runner.rb
+                    ${MODULE_ROOT_DIR}/test/unit-test/cmock/project.yml
+                    ${test_src_absolute}
+                    ${test_name}_runner.c
+                  DEPENDS ${test_src}
+        )
+    add_executable(${test_name} ${test_src} ${test_name}_runner.c)
+    set_target_properties(${test_name} PROPERTIES
+            COMPILE_FLAG "-O0 -ggdb"
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/tests"
+            INSTALL_RPATH_USE_LINK_PATH TRUE
+        )
+    target_include_directories(${test_name} PUBLIC
+                               ${mocks_dir}
+                               ${include_list}
+        )
+
+    target_link_directories(${test_name} PUBLIC
+                            ${CMAKE_CURRENT_BINARY_DIR}
+        )
+
+    # Link all libraries sent through parameters.
+    foreach(link IN LISTS link_list)
+        target_link_libraries(${test_name} ${link})
+    endforeach()
+
+    # Add dependency to all the dep_list parameter.
+    foreach(dependency IN LISTS dep_list)
+        add_dependencies(${test_name} ${dependency})
+        target_link_libraries(${test_name} ${dependency})
+    endforeach()
+    target_link_libraries(${test_name} unity)
+    target_link_directories(${test_name}  PUBLIC
+                            ${CMAKE_CURRENT_BINARY_DIR}/lib
+            )
+    add_test(NAME ${test_name}
+             COMMAND ${CMAKE_BINARY_DIR}/bin/tests/${test_name}
+             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            )
+endfunction()
+
+# Run the C preprocessor on target files.
+# Takes a CMAKE list of arguments to pass to the C compiler.
+function(preprocess_mock_list mock_name file_list compiler_args)
+    set_property(GLOBAL PROPERTY ${mock_name}_processed TRUE)
+    foreach (target_file IN LISTS file_list)
+        # Has to be TARGET ALL so the file is pre-processed before CMOCK
+        # is executed on the file.
+        add_custom_command(OUTPUT ${target_file}.backup
+            COMMAND scp ${target_file} ${target_file}.backup
+            VERBATIM COMMAND ${CMAKE_C_COMPILER} -E ${compiler_args} ${target_file} > ${target_file}.out
+        )
+        add_custom_target(pre_${mock_name}
+            COMMAND mv ${target_file}.out ${target_file}
+            DEPENDS ${target_file}.backup
+        )
+    endforeach()
+
+    # Clean up temporary files that were created.
+    # First we test to see if the backup file still exists. If it does we revert
+    # the change made to the original file.
+    foreach (target_file IN LISTS file_list)
+        add_custom_command(TARGET ${mock_name}
+            POST_BUILD
+            COMMAND test ! -e ${target_file}.backup || mv ${target_file}.backup ${target_file}
+        )
+    endforeach()
+endfunction()
+
+# Generates a mock library based on a module's header file
+# places the generated source file in the build directory.
+# @param mock_name: name of the target name.
+# @param mock_list list of header files to mock.
+# @param cmock_config configuration file of the cmock framework.
+# @param mock_include_list include list for the target.
+# @param mock_define_list special definitions to control compilation.
+function(create_mock_list mock_name
+                          mock_list
+                          cmock_config
+                          mock_include_list
+                          mock_define_list)
+    set(mocks_dir "${CMAKE_CURRENT_BINARY_DIR}/mocks")
+    add_library(${mock_name} SHARED)
+    foreach (mock_file IN LISTS mock_list)
+        get_filename_component(mock_file_abs
+                               ${mock_file}
+                               ABSOLUTE
+                )
+        get_filename_component(mock_file_name
+                               ${mock_file}
+                               NAME_WLE
+                )
+        get_filename_component(mock_file_dir
+                               ${mock_file}
+                               DIRECTORY
+                )
+        add_custom_command (
+                  OUTPUT ${mocks_dir}/mock_${mock_file_name}.c
+                  COMMAND ruby
+                  ${CMOCK_DIR}/lib/cmock.rb
+                  -o${cmock_config} ${mock_file_abs}
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                )
+        target_sources(${mock_name} PUBLIC
+                       ${mocks_dir}/mock_${mock_file_name}.c
+        )
+
+        target_include_directories(${mock_name} PUBLIC
+                                   ${mock_file_dir}
+        )
+    endforeach()
+    target_include_directories(${mock_name} PUBLIC
+                               ${mocks_dir}
+                               ${mock_include_list}
+           )
+
+    if (APPLE)
+        set_target_properties(${mock_name} PROPERTIES
+                              LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+                              POSITION_INDEPENDENT_CODE ON
+                              LINK_FLAGS "-Wl,-undefined,dynamic_lookup"
+                             )
+    else()
+        set_target_properties(${mock_name} PROPERTIES
+                              LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+                              POSITION_INDEPENDENT_CODE ON
+                             )
+    endif()
+
+    target_compile_definitions(${mock_name} PUBLIC
+            ${mock_define_list}
+        )
+    target_link_libraries(${mock_name} cmock unity)
+endfunction()
+
+
+function(create_real_library target
+                             src_file
+                             real_include_list
+                             mock_name)
+    add_library(${target} STATIC
+            ${src_file}
+        )
+    target_include_directories(${target} PUBLIC
+            ${real_include_list}
+        )
+    set_target_properties(${target} PROPERTIES
+                COMPILE_FLAGS "-Wextra -Wpedantic \
+                    -fprofile-arcs -ftest-coverage -fprofile-generate \
+                    -Wno-unused-but-set-variable"
+                LINK_FLAGS "-fprofile-arcs -ftest-coverage \
+                    -fprofile-generate "
+                ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+            )
+    if(NOT(mock_name STREQUAL ""))
+        add_dependencies(${target} ${mock_name})
+        target_link_libraries(${target}
+                        -l${mock_name}
+                )
+    endif()
+endfunction()

--- a/test/unit-test/cmock/project.yml
+++ b/test/unit-test/cmock/project.yml
@@ -1,0 +1,25 @@
+:cmock:
+  :mock_prefix: mock_
+  :when_no_prototypes: :warn
+  :enforce_strict_ordering: TRUE
+  :plugins:
+    - :ignore
+    - :ignore_arg
+    - :expect_any_args
+    - :array
+    - :callback
+    - :return_thru_ptr
+  :callback_include_count: true # Include a count arg when calling the callback.
+  :callback_after_arg_check: false # Check arguments before calling the callback.
+  :treat_as:
+    uint8:    HEX8
+    uint16:   HEX16
+    uint32:   UINT32
+    int8:     INT8
+    bool:     UINT8
+  :includes:        # This will add these includes to each mock.
+    - <stdbool.h>
+    - <stdint.h>
+  :treat_externs: :exclude  # Now the extern-ed functions will be mocked.
+  :weak: __attribute__((weak))
+  :treat_externs: :include

--- a/test/unit-test/cmock_build.cmake
+++ b/test/unit-test/cmock_build.cmake
@@ -1,0 +1,59 @@
+# Macro utility to clone the CMock submodule.
+macro( clone_cmock )
+        find_package( Git REQUIRED )
+        message( "Cloning submodule CMock." )
+        execute_process( COMMAND rm -rf ${CMOCK_DIR}
+                         COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive --checkout ${CMOCK_DIR}
+                        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                        RESULT_VARIABLE CMOCK_CLONE_RESULT )
+
+        if( NOT ${CMOCK_CLONE_RESULT} STREQUAL "0" )
+                message( FATAL_ERROR "Failed to clone CMock submodule." )
+        endif()
+endmacro()
+
+# Macro utility to add library targets for Unity and CMock to build configuration.
+macro( add_cmock_targets )
+        # Build Configuration for CMock and Unity libraries.
+        list( APPEND CMOCK_INCLUDE_DIRS
+                "${CMOCK_DIR}/vendor/unity/src/"
+                "${CMOCK_DIR}/vendor/unity/extras/fixture/src"
+                "${CMOCK_DIR}/vendor/unity/extras/memory/src"
+                "${CMOCK_DIR}/src"
+        )
+
+        add_library(cmock STATIC
+        "${CMOCK_DIR}/src/cmock.c"
+        )
+
+        set_target_properties(cmock PROPERTIES
+                ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+                POSITION_INDEPENDENT_CODE ON
+                COMPILE_FLAGS "-Og"
+                )
+
+        target_include_directories(cmock PUBLIC
+                ${CMOCK_DIR}/src
+                ${CMOCK_DIR}/vendor/unity/src/
+                ${CMOCK_DIR}/examples
+                ${CMOCK_INCLUDE_DIRS}
+                )
+
+        add_library(unity STATIC
+                "${CMOCK_DIR}/vendor/unity/src/unity.c"
+                "${CMOCK_DIR}/vendor/unity/extras/fixture/src/unity_fixture.c"
+                "${CMOCK_DIR}/vendor/unity/extras/memory/src/unity_memory.c"
+                )
+
+        set_target_properties(unity PROPERTIES
+                ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+                POSITION_INDEPENDENT_CODE ON
+                )
+
+        target_include_directories(unity PUBLIC
+                ${CMOCK_INCLUDE_DIRS}
+                )
+
+        target_link_libraries(cmock unity)
+endmacro()
+

--- a/test/unit-test/stun_deserializer/stun_deserializer_utest.c
+++ b/test/unit-test/stun_deserializer/stun_deserializer_utest.c
@@ -13,8 +13,6 @@
 
 /* ===========================  EXTERN VARIABLES  =========================== */
 
-#define MAX_MESSAGE_LENGTH        20
-
 void setUp( void )
 {
 }
@@ -34,42 +32,48 @@ void test_StunDeserializer_Init_Pass( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t pStunMessage[MAX_MESSAGE_LENGTH];
-    size_t stunMessageLength = MAX_MESSAGE_LENGTH;
-    uint8_t transactionId[STUN_HEADER_TRANSACTION_ID_LENGTH] = { 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0 };
-
-    pStunMessage[0] = STUN_MESSAGE_TYPE_BINDING_REQUEST >> 8;
-    pStunMessage[1] = STUN_MESSAGE_TYPE_BINDING_REQUEST & 0xFF;
-    pStunMessage[2] = 0;
-    pStunMessage[3] = 0;
-    pStunMessage[4] = STUN_HEADER_MAGIC_COOKIE >> 24;
-    pStunMessage[5] = ( STUN_HEADER_MAGIC_COOKIE >> 16 ) & 0xFF;
-    pStunMessage[6] = ( STUN_HEADER_MAGIC_COOKIE >> 8 ) & 0xFF;
-    pStunMessage[7] = STUN_HEADER_MAGIC_COOKIE & 0xFF;
-    memcpy( &pStunMessage[8],
-            transactionId,
-            STUN_HEADER_TRANSACTION_ID_LENGTH );
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
+                                                                   0x78, 0x9A, 0xBC,
+                                                                   0xDE, 0xF0, 0xAB,
+                                                                   0xCD, 0xEF, 0xA5 };
+    uint8_t serializedHeader[ STUN_HEADER_LENGTH ] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x80. */
+        0x00, 0x01, 0x00, 0x80,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
+    size_t stunMessageLength = STUN_HEADER_LENGTH + 0x80; /* 0x80 is the payload length
+                                                           * as specified in the header. */
 
     result = StunDeserializer_Init( &( ctx ),
-                                    &( pStunMessage[0] ),
+                                    &( serializedHeader[ 0 ] ),
                                     stunMessageLength,
                                     &( header ) );
 
-    TEST_ASSERT_EQUAL_INT( STUN_RESULT_OK,
-                           result );
-    TEST_ASSERT_EQUAL_HEX16( STUN_MESSAGE_TYPE_BINDING_REQUEST,
-                             header.messageType );
-    TEST_ASSERT_EQUAL_HEX8_ARRAY( transactionId,
-                                  header.pTransactionId,
-                                  STUN_HEADER_TRANSACTION_ID_LENGTH );
-    TEST_ASSERT_EQUAL_PTR( pStunMessage,
-                           ctx.pStart );
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( &( serializedHeader[ 0 ] ),
+                       ctx.pStart );
     TEST_ASSERT_EQUAL( stunMessageLength,
                        ctx.totalLength );
     TEST_ASSERT_EQUAL( STUN_HEADER_LENGTH,
                        ctx.currentIndex );
     TEST_ASSERT_EQUAL( 0,
                        ctx.attributeFlag );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint16Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint32Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint64Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint16Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint32Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint64Fn );
+    TEST_ASSERT_EQUAL( STUN_MESSAGE_TYPE_BINDING_REQUEST,
+                       header.messageType );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( transactionId[ 0 ] ),
+                                   header.pTransactionId,
+                                   STUN_HEADER_TRANSACTION_ID_LENGTH );
 }
 
 /*-----------------------------------------------------------*/
@@ -82,48 +86,39 @@ void test_StunDeserializer_Init_BadParams( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t pStunMessage[MAX_MESSAGE_LENGTH];
-    size_t stunMessageLength;
-
-    stunMessageLength = MAX_MESSAGE_LENGTH;
+    uint8_t stunMessage[ STUN_HEADER_LENGTH ];
 
     result = StunDeserializer_Init( NULL,
-                                    &( pStunMessage[0] ),
-                                    stunMessageLength,
+                                    &( stunMessage[ 0 ] ),
+                                    STUN_HEADER_LENGTH,
                                     &( header ) );
 
     TEST_ASSERT_EQUAL_INT( STUN_RESULT_BAD_PARAM,
                            result );
-
-    stunMessageLength = MAX_MESSAGE_LENGTH;
 
     result = StunDeserializer_Init( &( ctx ),
                                     NULL,
-                                    stunMessageLength,
+                                    STUN_HEADER_LENGTH,
                                     &( header ) );
 
     TEST_ASSERT_EQUAL_INT( STUN_RESULT_BAD_PARAM,
                            result );
 
-    stunMessageLength = 10;
-
     result = StunDeserializer_Init( &( ctx ),
-                                    &( pStunMessage[0] ),
-                                    stunMessageLength,
+                                    &( stunMessage[ 0 ] ),
+                                    10, /* Message length less than STUN_HEADER_LENGTH. */
                                     &( header ) );
 
     TEST_ASSERT_EQUAL_INT( STUN_RESULT_BAD_PARAM,
                            result );
 
-    stunMessageLength = MAX_MESSAGE_LENGTH;
-
     result = StunDeserializer_Init( &( ctx ),
-                                    &( pStunMessage[0] ),
-                                    stunMessageLength,
+                                    &( stunMessage [ 0 ] ),
+                                    STUN_HEADER_LENGTH,
                                     NULL );
 
     TEST_ASSERT_EQUAL_INT( STUN_RESULT_BAD_PARAM,
                            result );
-
 }
 
+/*-----------------------------------------------------------*/

--- a/test/unit-test/stun_deserializer/stun_deserializer_utest.c
+++ b/test/unit-test/stun_deserializer/stun_deserializer_utest.c
@@ -1,0 +1,129 @@
+/* Unity includes. */
+#include "unity.h"
+#include "catch_assert.h"
+
+/* Standard includes. */
+#include <string.h>
+#include <stdint.h>
+
+/* API includes. */
+#include "stun_deserializer.h"
+#include "stun_endianness.h"
+#include "stun_data_types.h"
+
+/* ===========================  EXTERN VARIABLES  =========================== */
+
+#define MAX_MESSAGE_LENGTH        20
+
+void setUp( void )
+{
+}
+
+void tearDown( void )
+{
+}
+
+/* ==============================  Test Cases ============================== */
+
+/**
+ * @brief Validate Validate StunDeserializer_Init incase of happy path.
+ */
+
+void test_StunDeserializer_Init_Pass( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t pStunMessage[MAX_MESSAGE_LENGTH];
+    size_t stunMessageLength = MAX_MESSAGE_LENGTH;
+    uint8_t transactionId[STUN_HEADER_TRANSACTION_ID_LENGTH] = { 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0 };
+
+    pStunMessage[0] = STUN_MESSAGE_TYPE_BINDING_REQUEST >> 8;
+    pStunMessage[1] = STUN_MESSAGE_TYPE_BINDING_REQUEST & 0xFF;
+    pStunMessage[2] = 0;
+    pStunMessage[3] = 0;
+    pStunMessage[4] = STUN_HEADER_MAGIC_COOKIE >> 24;
+    pStunMessage[5] = ( STUN_HEADER_MAGIC_COOKIE >> 16 ) & 0xFF;
+    pStunMessage[6] = ( STUN_HEADER_MAGIC_COOKIE >> 8 ) & 0xFF;
+    pStunMessage[7] = STUN_HEADER_MAGIC_COOKIE & 0xFF;
+    memcpy( &pStunMessage[8],
+            transactionId,
+            STUN_HEADER_TRANSACTION_ID_LENGTH );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( pStunMessage[0] ),
+                                    stunMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL_INT( STUN_RESULT_OK,
+                           result );
+    TEST_ASSERT_EQUAL_HEX16( STUN_MESSAGE_TYPE_BINDING_REQUEST,
+                             header.messageType );
+    TEST_ASSERT_EQUAL_HEX8_ARRAY( transactionId,
+                                  header.pTransactionId,
+                                  STUN_HEADER_TRANSACTION_ID_LENGTH );
+    TEST_ASSERT_EQUAL_PTR( pStunMessage,
+                           ctx.pStart );
+    TEST_ASSERT_EQUAL( stunMessageLength,
+                       ctx.totalLength );
+    TEST_ASSERT_EQUAL( STUN_HEADER_LENGTH,
+                       ctx.currentIndex );
+    TEST_ASSERT_EQUAL( 0,
+                       ctx.attributeFlag );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Validate StunDeserializer_Init incase of bad parameters.
+ */
+void test_StunDeserializer_Init_BadParams( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t pStunMessage[MAX_MESSAGE_LENGTH];
+    size_t stunMessageLength;
+
+    stunMessageLength = MAX_MESSAGE_LENGTH;
+
+    result = StunDeserializer_Init( NULL,
+                                    &( pStunMessage[0] ),
+                                    stunMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL_INT( STUN_RESULT_BAD_PARAM,
+                           result );
+
+    stunMessageLength = MAX_MESSAGE_LENGTH;
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    NULL,
+                                    stunMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL_INT( STUN_RESULT_BAD_PARAM,
+                           result );
+
+    stunMessageLength = 10;
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( pStunMessage[0] ),
+                                    stunMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL_INT( STUN_RESULT_BAD_PARAM,
+                           result );
+
+    stunMessageLength = MAX_MESSAGE_LENGTH;
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( pStunMessage[0] ),
+                                    stunMessageLength,
+                                    NULL );
+
+    TEST_ASSERT_EQUAL_INT( STUN_RESULT_BAD_PARAM,
+                           result );
+
+}
+

--- a/test/unit-test/stun_deserializer/ut.cmake
+++ b/test/unit-test/stun_deserializer/ut.cmake
@@ -1,0 +1,88 @@
+
+# Include filepaths for source and include.
+include( ${MODULE_ROOT_DIR}/stunFilePaths.cmake )
+
+# ====================  Define your project name (edit) ========================
+set( project_name "stun_deserializer" )
+
+message( STATUS "${project_name}" )
+
+# =====================  Create your mock here  (edit)  ========================
+
+# List the files to mock here.
+list(APPEND mock_list
+            "${MODULE_ROOT_DIR}/source/include/stun_deserializer.h"
+            "${MODULE_ROOT_DIR}/source/include/stun_data_types.h"
+            "${MODULE_ROOT_DIR}/source/include/stun_endianness.h"
+        )
+# List the directories your mocks need.
+list(APPEND mock_include_list
+            ${STUN_INCLUDE_PUBLIC_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test
+        )
+
+# List the definitions of your mocks to control what to be included.
+list(APPEND mock_define_list
+            ""
+       )
+
+# ================= Create the library under test here (edit) ==================
+
+# List the files you would like to test here.
+list(APPEND real_source_files
+            ${MODULE_ROOT_DIR}/source/stun_deserializer.c
+            ${MODULE_ROOT_DIR}/source/stun_endianness.c
+        )
+# List the directories the module under test includes.
+list(APPEND real_include_directories
+            ${STUN_INCLUDE_PUBLIC_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test
+            ${CMOCK_DIR}/vendor/unity/src
+        )
+
+# =====================  Create UnitTest Code here (edit)  =====================
+
+# list the directories your test needs to include.
+list(APPEND test_include_directories
+            ${CMOCK_DIR}/vendor/unity/src
+            ${STUN_INCLUDE_PUBLIC_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test
+        )
+
+# =============================  (end edit)  ===================================
+
+set(mock_name "${project_name}_mock")
+set(real_name "${project_name}_real")
+
+create_mock_list(${mock_name}
+                "${mock_list}"
+                "${MODULE_ROOT_DIR}/test/unit-test/cmock/project.yml"
+                "${mock_include_list}"
+                "${mock_define_list}"
+        )
+
+create_real_library(${real_name}
+                    "${real_source_files}"
+                    "${real_include_directories}"
+                    "${mock_name}"
+        )
+
+list(APPEND utest_link_list
+            lib${real_name}.a
+        )
+
+list(APPEND utest_dep_list
+            ${real_name}
+        )
+
+set(utest_name "${project_name}_utest")
+set(utest_source "${project_name}/${project_name}_utest.c")
+
+create_test(${utest_name}
+            ${utest_source}
+            "${utest_link_list}"
+            "${utest_dep_list}"
+            "${test_include_directories}"
+        )
+
+        

--- a/test/unit-test/stun_deserializer/ut.cmake
+++ b/test/unit-test/stun_deserializer/ut.cmake
@@ -84,5 +84,3 @@ create_test(${utest_name}
             "${utest_dep_list}"
             "${test_include_directories}"
         )
-
-        

--- a/test/unit-test/stun_serializer/stun_serializer_utest.c
+++ b/test/unit-test/stun_serializer/stun_serializer_utest.c
@@ -1,0 +1,121 @@
+/* Unity includes. */
+#include "unity.h"
+#include "catch_assert.h"
+
+/* Standard includes. */
+#include <string.h>
+#include <stdint.h>
+
+/* API includes. */
+#include "stun_serializer.h"
+#include "stun_endianness.h"
+#include "stun_data_types.h"
+
+/* ===========================  EXTERN VARIABLES  =========================== */
+
+#define MAX_BUFFER_LENGTH        20
+
+void setUp( void )
+{
+}
+
+void tearDown( void )
+{
+}
+
+/* ==============================  Test Cases ============================== */
+
+/**
+ * @brief Validate StunSerializer_Init in the happy path.
+ */
+void test_StunSerializer_Init_Pass( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header;
+    uint8_t pBuffer[MAX_BUFFER_LENGTH];
+    size_t bufferLength;
+    uint8_t transactionId[STUN_HEADER_TRANSACTION_ID_LENGTH] = { 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0 };
+
+    result = StunSerializer_Init( &( ctx ),
+                                  NULL,
+                                  0,
+                                  &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
+    header.pTransactionId = &( transactionId[0] );
+    bufferLength = MAX_BUFFER_LENGTH;
+
+    result = StunSerializer_Init( &ctx,
+                                  pBuffer,
+                                  bufferLength,
+                                  &header );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_PTR( pBuffer,
+                           ctx.pStart );
+    TEST_ASSERT_EQUAL( bufferLength,
+                       ctx.totalLength );
+    TEST_ASSERT_EQUAL( STUN_HEADER_LENGTH,
+                       ctx.currentIndex );
+    TEST_ASSERT_EQUAL( 0,
+                       ctx.attributeFlag );
+    TEST_ASSERT_EQUAL_HEX16( header.messageType,
+                             ( pBuffer[0] << 8 ) | pBuffer[1] );
+    TEST_ASSERT_EQUAL_HEX16( 0,
+                             ( pBuffer[STUN_HEADER_MESSAGE_LENGTH_OFFSET] << 8 ) | pBuffer[STUN_HEADER_MESSAGE_LENGTH_OFFSET + 1] );
+    TEST_ASSERT_EQUAL_HEX32( STUN_HEADER_MAGIC_COOKIE,
+                             ( pBuffer[STUN_HEADER_MAGIC_COOKIE_OFFSET] << 24 ) | ( pBuffer[STUN_HEADER_MAGIC_COOKIE_OFFSET + 1] << 16 ) | ( pBuffer[STUN_HEADER_MAGIC_COOKIE_OFFSET + 2] << 8 ) | pBuffer[STUN_HEADER_MAGIC_COOKIE_OFFSET + 3] );
+    TEST_ASSERT_EQUAL_HEX8_ARRAY( transactionId,
+                                  &( pBuffer[STUN_HEADER_TRANSACTION_ID_OFFSET] ),
+                                  STUN_HEADER_TRANSACTION_ID_LENGTH );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunSerializer_Init incase of bad parameters.
+ */
+void test_StunSerializer_Init_BadParams( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header;
+    uint8_t pBuffer[MAX_BUFFER_LENGTH];
+    size_t bufferLength;
+
+    bufferLength = MAX_BUFFER_LENGTH;
+
+    result = StunSerializer_Init( NULL,
+                                  &( pBuffer[0] ),
+                                  bufferLength,
+                                  &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
+                       result );
+
+    bufferLength = MAX_BUFFER_LENGTH;
+
+    result = StunSerializer_Init( &( ctx ),
+                                  &( pBuffer[0] ),
+                                  bufferLength,
+                                  NULL );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
+                       result );
+
+    bufferLength = 10;
+
+    result = StunSerializer_Init( &( ctx ),
+                                  &( pBuffer[0] ),
+                                  bufferLength,
+                                  &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
+                       result );
+}
+

--- a/test/unit-test/stun_serializer/ut.cmake
+++ b/test/unit-test/stun_serializer/ut.cmake
@@ -1,0 +1,88 @@
+
+# Include filepaths for source and include.
+include( ${MODULE_ROOT_DIR}/stunFilePaths.cmake )
+
+# ====================  Define your project name (edit) ========================
+set( project_name "stun_serializer" )
+
+message( STATUS "${project_name}" )
+
+# =====================  Create your mock here  (edit)  ========================
+
+# List the files to mock here.
+list(APPEND mock_list
+            "${MODULE_ROOT_DIR}/source/include/stun_serializer.h"
+            "${MODULE_ROOT_DIR}/source/include/stun_data_types.h"
+            "${MODULE_ROOT_DIR}/source/include/stun_endianness.h"
+        )
+# List the directories your mocks need.
+list(APPEND mock_include_list
+            ${STUN_INCLUDE_PUBLIC_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test
+        )
+
+# List the definitions of your mocks to control what to be included.
+list(APPEND mock_define_list
+            ""
+       )
+
+# ================= Create the library under test here (edit) ==================
+
+# List the files you would like to test here.
+list(APPEND real_source_files
+            ${MODULE_ROOT_DIR}/source/stun_serializer.c
+            ${MODULE_ROOT_DIR}/source/stun_endianness.c
+        )
+# List the directories the module under test includes.
+list(APPEND real_include_directories
+            ${STUN_INCLUDE_PUBLIC_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test
+            ${CMOCK_DIR}/vendor/unity/src
+        )
+
+# =====================  Create UnitTest Code here (edit)  =====================
+
+# list the directories your test needs to include.
+list(APPEND test_include_directories
+            ${CMOCK_DIR}/vendor/unity/src
+            ${STUN_INCLUDE_PUBLIC_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test
+        )
+
+# =============================  (end edit)  ===================================
+
+set(mock_name "${project_name}_mock")
+set(real_name "${project_name}_real")
+
+create_mock_list(${mock_name}
+                "${mock_list}"
+                "${MODULE_ROOT_DIR}/test/unit-test/cmock/project.yml"
+                "${mock_include_list}"
+                "${mock_define_list}"
+        )
+
+create_real_library(${real_name}
+                    "${real_source_files}"
+                    "${real_include_directories}"
+                    "${mock_name}"
+        )
+
+list(APPEND utest_link_list
+            lib${real_name}.a
+        )
+
+list(APPEND utest_dep_list
+            ${real_name}
+        )
+
+set(utest_name "${project_name}_utest")
+set(utest_source "${project_name}/${project_name}_utest.c")
+
+create_test(${utest_name}
+            ${utest_source}
+            "${utest_link_list}"
+            "${utest_dep_list}"
+            "${test_include_directories}"
+        )
+
+        

--- a/test/unit-test/stun_serializer/ut.cmake
+++ b/test/unit-test/stun_serializer/ut.cmake
@@ -84,5 +84,3 @@ create_test(${utest_name}
             "${utest_dep_list}"
             "${test_include_directories}"
         )
-
-        


### PR DESCRIPTION
*Description of changes:*
This PR adds unit-tests structure for stun serialization and deserialization. 

*Test Steps:*

```
git submodule update --init --recursive --checkout test/CMock
cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build
ctest -E system --output-on-failure
make coverage
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
