### PR TITLE
Add unit-tests for AddAttributeErrorCode function

### DIFF
--- a/test/unit-test/stun_deserializer/stun_deserializer_utest.c
+++ b/test/unit-test/stun_deserializer/stun_deserializer_utest.c
@@ -24,7 +24,7 @@ void tearDown( void )
 /* ==============================  Test Cases ============================== */
 
 /**
- * @brief Validate Validate StunDeserializer_Init incase of happy path.
+ * @brief Validate StunDeserializer_Init incase of happy path.
  */
 
 void test_StunDeserializer_Init_Pass( void )
@@ -79,7 +79,7 @@ void test_StunDeserializer_Init_Pass( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Validate StunDeserializer_Init incase of bad parameters.
+ * @brief Validate StunDeserializer_Init incase of bad parameters.
  */
 void test_StunDeserializer_Init_BadParams( void )
 {

--- a/test/unit-test/stun_serializer/stun_serializer_utest.c
+++ b/test/unit-test/stun_serializer/stun_serializer_utest.c
@@ -13,7 +13,7 @@
 
 /* ===========================  EXTERN VARIABLES  =========================== */
 
-#define MAX_BUFFER_LENGTH        20
+#define MAX_BUFFER_LENGTH        512
 
 void setUp( void )
 {
@@ -149,3 +149,318 @@ void test_StunSerializer_Init_BadParams( void )
 }
 
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunSerializer_AddAttributeErrorCode in the happy path.
+ */
+void test_StunSerializer_AddAttributeErrorCode_Pass_( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t buffer[ MAX_BUFFER_LENGTH ] = { 0 };
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
+                                                                   0x78, 0x9A, 0xBC,
+                                                                   0xDE, 0xF0, 0xAB,
+                                                                   0xCD, 0xEF, 0xA5 };
+    const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
+    uint16_t errorPhraseLength = strlen( ( const char * ) errorPhrase );
+    uint16_t errorCode = 0x0600;
+    size_t expectedLength;
+    uint8_t expectedStunMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 20. */
+        0x00, 0x01, 0x00, 0x14,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute Type = Error Code, Attribute Length = 20 */
+        0x00, 0x09, 0x00, 0x10,
+        /* Reserved = 0, Error Code = 600 */
+        0x00, 0x00, 0x06, 0x00,
+        /* Error Phrase */
+        0x45, 0x72, 0x72, 0x6F, 0x72, 0x20, 0x50, 0x68, 0x72, 0x61, 0x73, 0x65
+    };
+    size_t expectedStunMessageLength = sizeof( expectedStunMessage );
+
+    header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
+    header.pTransactionId = &( transactionId[ 0 ] );
+
+    result = StunSerializer_Init( &( ctx ),
+                                  &( buffer[0] ),
+                                  MAX_BUFFER_LENGTH,
+                                  &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunSerializer_AddAttributeErrorCode( &( ctx ),
+                                                   errorCode,
+                                                   &( errorPhrase[0] ),
+                                                   errorPhraseLength );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunSerializer_Finalize( &( ctx ),
+                                      &( expectedLength ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedStunMessage,
+                                   buffer,
+                                   expectedStunMessageLength );
+
+    TEST_ASSERT_EQUAL( expectedLength,
+                       expectedStunMessageLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunSerializer_AddAttributeErrorCode with NULL context.
+ */
+void test_StunSerializer_AddAttributeErrorCode_NullContext( void )
+{
+    StunResult_t result;
+    const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
+    uint16_t errorPhraseLength = strlen( ( const char * ) errorPhrase );
+    uint16_t errorCode = 0x0600;
+
+    result = StunSerializer_AddAttributeErrorCode( NULL,
+                                                   errorCode,
+                                                   &( errorPhrase[0] ),
+                                                   errorPhraseLength );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunSerializer_AddAttributeErrorCode with NULL error phrase.
+ */
+void test_StunSerializer_AddAttributeErrorCode_NullErrorPhrase( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t buffer[ MAX_BUFFER_LENGTH ] = { 0 };
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
+                                                                   0x78, 0x9A, 0xBC,
+                                                                   0xDE, 0xF0, 0xAB,
+                                                                   0xCD, 0xEF, 0xA5 };
+    uint16_t errorCode = 0x0600; 
+
+    header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
+    header.pTransactionId = &( transactionId[ 0 ] );
+
+    result = StunSerializer_Init( &( ctx ),
+                                  &( buffer[0] ),
+                                  MAX_BUFFER_LENGTH,
+                                  &( header ) );
+                                  
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunSerializer_AddAttributeErrorCode( &( ctx ),
+                                                   errorCode,
+                                                   NULL,
+                                                   0 );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunSerializer_AddAttributeErrorCode with zero error phrase length.
+ */
+void test_StunSerializer_AddAttributeErrorCode_ZeroErrorPhraseLength( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t buffer[ MAX_BUFFER_LENGTH ] = { 0 };
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
+                                                                   0x78, 0x9A, 0xBC,
+                                                                   0xDE, 0xF0, 0xAB,
+                                                                   0xCD, 0xEF, 0xA5 };
+    const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
+    uint16_t errorCode = 0x0600; 
+
+    header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
+    header.pTransactionId = &( transactionId[ 0 ] );
+
+    result = StunSerializer_Init( &( ctx ),
+                                  &( buffer[0] ),
+                                  MAX_BUFFER_LENGTH,
+                                  &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+     result = StunSerializer_AddAttributeErrorCode( NULL,
+                                                   errorCode,
+                                                   &( errorPhrase[0] ),
+                                                   0);
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunSerializer_AddAttributeErrorCode when pCtx->pStart is null.
+ */
+void test_StunSerializer_AddAttributeErrorCode_pStartNull( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t buffer[ MAX_BUFFER_LENGTH ] = { 0 };
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
+                                                                   0x78, 0x9A, 0xBC,
+                                                                   0xDE, 0xF0, 0xAB,
+                                                                   0xCD, 0xEF, 0xA5 };
+    const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
+    uint16_t errorPhraseLength = sizeof(errorPhrase );
+    uint16_t errorCode = 0x0600;
+
+    header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
+    header.pTransactionId = &( transactionId[ 0 ] );
+
+     result = StunSerializer_Init( &( ctx ),
+                                  &( buffer[0] ),
+                                  MAX_BUFFER_LENGTH,
+                                  &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    ctx.pStart = NULL; /* Set pCtx->pStart to NULL */
+
+    result = StunSerializer_AddAttributeErrorCode( &(ctx),
+                                                   errorCode,
+                                                   &(errorPhrase[0]),
+                                                   errorPhraseLength );
+                                                   
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunSerializer_AddAttributeErrorCode in case of out of memory.
+ */
+void test_StunSerializer_AddAttributeErrorCode_OutOfMemory( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t buffer[ 20 ] = { 0 };
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
+                                                                   0x78, 0x9A, 0xBC,
+                                                                   0xDE, 0xF0, 0xAB,
+                                                                   0xCD, 0xEF, 0xA5 };
+    const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
+    uint16_t errorPhraseLength = strlen( ( const char * ) errorPhrase );
+    uint16_t errorCode = 0x0600;
+
+    header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
+    header.pTransactionId = &( transactionId[ 0 ] );
+
+    result = StunSerializer_Init( &( ctx ),
+                                  &( buffer[0] ),
+                                  20,
+                                  &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunSerializer_AddAttributeErrorCode( &( ctx ),
+                                                   errorCode,
+                                                   &( errorPhrase[0] ),
+                                                   errorPhraseLength );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunSerializer_AddAttributeErrorCode in case of short error phrase.
+ */
+void test_StunSerializer_AddAttributeErrorCode_Short( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t buffer[ MAX_BUFFER_LENGTH ] = { 0 };
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
+                                                                   0x78, 0x9A, 0xBC,
+                                                                   0xDE, 0xF0, 0xAB,
+                                                                   0xCD, 0xEF, 0xA5 };
+    const uint8_t * errorPhrase = ( const uint8_t * ) "Short";
+    uint16_t errorPhraseLength = strlen( ( const char * ) errorPhrase );
+    uint16_t errorCode = 0x0600;
+    size_t expectedLength;
+    uint8_t expectedStunMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 20. */
+        0x00, 0x01, 0x00, 0x10,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute Type = Error Code, Attribute Length = 20 */
+        0x00, 0x09, 0x00, 0x09,
+        /* Reserved = 0, Error Code = 600 */
+        0x00, 0x00, 0x06, 0x00,
+        /* Error Phrase */
+        0x53, 0x68, 0x6F, 0x72, 0x74, 0x00, 0x00, 0x00
+    };
+    size_t expectedStunMessageLength = sizeof( expectedStunMessage );
+
+    header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
+    header.pTransactionId = &( transactionId[ 0 ] );
+
+    result = StunSerializer_Init( &( ctx ),
+                                  &( buffer[0] ),
+                                  MAX_BUFFER_LENGTH,
+                                  &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunSerializer_AddAttributeErrorCode( &( ctx ),
+                                                   errorCode,
+                                                   &( errorPhrase[0] ),
+                                                   errorPhraseLength );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunSerializer_Finalize( &( ctx ),
+                                      &( expectedLength ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedStunMessage,
+                                   buffer,
+                                   expectedStunMessageLength );
+
+    TEST_ASSERT_EQUAL( expectedLength,
+                       expectedStunMessageLength );
+}
+
+/*-----------------------------------------------------------*/
+

--- a/test/unit-test/stun_serializer/stun_serializer_utest.c
+++ b/test/unit-test/stun_serializer/stun_serializer_utest.c
@@ -253,7 +253,7 @@ void test_StunSerializer_AddAttributeErrorCode_NullErrorPhrase( void )
                                                                    0x78, 0x9A, 0xBC,
                                                                    0xDE, 0xF0, 0xAB,
                                                                    0xCD, 0xEF, 0xA5 };
-    uint16_t errorCode = 0x0600; 
+    uint16_t errorCode = 0x0600;
 
     header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
     header.pTransactionId = &( transactionId[ 0 ] );
@@ -262,7 +262,7 @@ void test_StunSerializer_AddAttributeErrorCode_NullErrorPhrase( void )
                                   &( buffer[0] ),
                                   MAX_BUFFER_LENGTH,
                                   &( header ) );
-                                  
+
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
@@ -291,7 +291,7 @@ void test_StunSerializer_AddAttributeErrorCode_ZeroErrorPhraseLength( void )
                                                                    0xDE, 0xF0, 0xAB,
                                                                    0xCD, 0xEF, 0xA5 };
     const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
-    uint16_t errorCode = 0x0600; 
+    uint16_t errorCode = 0x0600;
 
     header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
     header.pTransactionId = &( transactionId[ 0 ] );
@@ -304,10 +304,10 @@ void test_StunSerializer_AddAttributeErrorCode_ZeroErrorPhraseLength( void )
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
-     result = StunSerializer_AddAttributeErrorCode( NULL,
+    result = StunSerializer_AddAttributeErrorCode( &( ctx ),
                                                    errorCode,
                                                    &( errorPhrase[0] ),
-                                                   0);
+                                                   0 );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
                        result );
@@ -329,13 +329,14 @@ void test_StunSerializer_AddAttributeErrorCode_pStartNull( void )
                                                                    0xDE, 0xF0, 0xAB,
                                                                    0xCD, 0xEF, 0xA5 };
     const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
-    uint16_t errorPhraseLength = sizeof(errorPhrase );
+    uint16_t errorPhraseLength = sizeof( errorPhrase );
     uint16_t errorCode = 0x0600;
+    size_t expectedLength;
 
     header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
     header.pTransactionId = &( transactionId[ 0 ] );
 
-     result = StunSerializer_Init( &( ctx ),
+    result = StunSerializer_Init( &( ctx ),
                                   &( buffer[0] ),
                                   MAX_BUFFER_LENGTH,
                                   &( header ) );
@@ -345,11 +346,17 @@ void test_StunSerializer_AddAttributeErrorCode_pStartNull( void )
 
     ctx.pStart = NULL; /* Set pCtx->pStart to NULL */
 
-    result = StunSerializer_AddAttributeErrorCode( &(ctx),
+    result = StunSerializer_AddAttributeErrorCode( &( ctx ),
                                                    errorCode,
-                                                   &(errorPhrase[0]),
+                                                   &( errorPhrase[0] ),
                                                    errorPhraseLength );
-                                                   
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunSerializer_Finalize( &( ctx ),
+                                      &( expectedLength ) );
+
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 }
@@ -375,6 +382,9 @@ void test_StunSerializer_AddAttributeErrorCode_OutOfMemory( void )
 
     header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
     header.pTransactionId = &( transactionId[ 0 ] );
+
+    /* Passing a limited buffer length of 20 bytes (equal to the fixed length of the header)
+       to intentionally trigger an out-of-memory error when attempting to add the error code attribute. */
 
     result = StunSerializer_Init( &( ctx ),
                                   &( buffer[0] ),

--- a/test/unit-test/stun_serializer/stun_serializer_utest.c
+++ b/test/unit-test/stun_serializer/stun_serializer_utest.c
@@ -13,14 +13,38 @@
 
 /* ===========================  EXTERN VARIABLES  =========================== */
 
-#define MAX_BUFFER_LENGTH        512
+#define GUARD_LENGTH                32
+#define STUN_MESSAGE_BUFFER_LENGTH  512
+
+uint8_t stunMessageBuffer[ GUARD_LENGTH + STUN_MESSAGE_BUFFER_LENGTH + GUARD_LENGTH ];
+uint8_t * pStunMessageBuffer = NULL;
 
 void setUp( void )
 {
+    memset( &( stunMessageBuffer[ 0 ] ),
+            0xA5,
+            GUARD_LENGTH );
+
+    memset( &( stunMessageBuffer[ GUARD_LENGTH ] ),
+            0,
+            STUN_MESSAGE_BUFFER_LENGTH );
+
+    memset( &( stunMessageBuffer[ GUARD_LENGTH + STUN_MESSAGE_BUFFER_LENGTH ] ),
+            0xA5,
+            GUARD_LENGTH );
+
+    pStunMessageBuffer = &( stunMessageBuffer[ GUARD_LENGTH ] );
 }
 
 void tearDown( void )
 {
+    TEST_ASSERT_EACH_EQUAL_UINT8( 0xA5,
+                                  &( stunMessageBuffer[ 0 ] ),
+                                  GUARD_LENGTH );
+
+    TEST_ASSERT_EACH_EQUAL_UINT8( 0xA5,
+                                  &( stunMessageBuffer[ GUARD_LENGTH + STUN_MESSAGE_BUFFER_LENGTH ] ),
+                                  GUARD_LENGTH );
 }
 
 /* ==============================  Test Cases ============================== */
@@ -33,7 +57,6 @@ void test_StunSerializer_Init_Pass( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t buffer[ MAX_BUFFER_LENGTH ];
     uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
                                                                    0x78, 0x9A, 0xBC,
                                                                    0xDE, 0xF0, 0xAB,
@@ -52,15 +75,15 @@ void test_StunSerializer_Init_Pass( void )
     header.pTransactionId = &( transactionId[ 0 ] );
 
     result = StunSerializer_Init( &( ctx ),
-                                  &( buffer[ 0 ] ),
-                                  MAX_BUFFER_LENGTH,
+                                  pStunMessageBuffer,
+                                  STUN_MESSAGE_BUFFER_LENGTH,
                                   &( header ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_PTR( &( buffer[ 0 ] ),
+    TEST_ASSERT_EQUAL_PTR( pStunMessageBuffer,
                            ctx.pStart );
-    TEST_ASSERT_EQUAL( MAX_BUFFER_LENGTH,
+    TEST_ASSERT_EQUAL( STUN_MESSAGE_BUFFER_LENGTH,
                        ctx.totalLength );
     TEST_ASSERT_EQUAL( STUN_HEADER_LENGTH,
                        ctx.currentIndex );
@@ -121,26 +144,25 @@ void test_StunSerializer_Init_BadParams( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t buffer[ MAX_BUFFER_LENGTH ];
 
     result = StunSerializer_Init( NULL,
-                                  &( buffer[ 0 ] ),
-                                  MAX_BUFFER_LENGTH,
+                                  pStunMessageBuffer,
+                                  STUN_MESSAGE_BUFFER_LENGTH,
                                   &( header ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
                        result );
 
     result = StunSerializer_Init( &( ctx ),
-                                  &( buffer[ 0 ] ),
-                                  MAX_BUFFER_LENGTH,
+                                  pStunMessageBuffer,
+                                  STUN_MESSAGE_BUFFER_LENGTH,
                                   NULL );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
                        result );
 
     result = StunSerializer_Init( &( ctx ),
-                                  &( buffer[ 0 ] ),
+                                  pStunMessageBuffer,
                                   10, /* Buffer length less than STUN_HEADER_LENGTH. */
                                   &( header ) );
 
@@ -153,33 +175,33 @@ void test_StunSerializer_Init_BadParams( void )
 /**
  * @brief Validate StunSerializer_AddAttributeErrorCode in the happy path.
  */
-void test_StunSerializer_AddAttributeErrorCode_Pass_( void )
+void test_StunSerializer_AddAttributeErrorCode_Pass( void )
 {
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t buffer[ MAX_BUFFER_LENGTH ] = { 0 };
-    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
-                                                                   0x78, 0x9A, 0xBC,
-                                                                   0xDE, 0xF0, 0xAB,
-                                                                   0xCD, 0xEF, 0xA5 };
     const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
     uint16_t errorPhraseLength = strlen( ( const char * ) errorPhrase );
     uint16_t errorCode = 0x0600;
-    size_t expectedLength;
+    size_t stunMessageLength;
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
+    {
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
     uint8_t expectedStunMessage[] =
     {
-        /* Message Type = STUN Binding Request, Message Length = 20. */
+        /* Message Type = STUN Binding Request, Message Length = 20 (excluding 20 bytes header). */
         0x00, 0x01, 0x00, 0x14,
         /* Magic cookie. */
         0x21, 0x12, 0xA4, 0x42,
         /* Transaction ID. */
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
-        /* Attribute Type = Error Code, Attribute Length = 20 */
+        /* Attribute Type = Error Code (0x0009), Attribute Length = 16 (2 reserved bytes,
+         * 2 byte error code and 12 byte error phrase). */
         0x00, 0x09, 0x00, 0x10,
-        /* Reserved = 0, Error Code = 600 */
+        /* Reserved = 0x0000, Error Code = 0x0600. */
         0x00, 0x00, 0x06, 0x00,
-        /* Error Phrase */
+        /* Error Phrase. */
         0x45, 0x72, 0x72, 0x6F, 0x72, 0x20, 0x50, 0x68, 0x72, 0x61, 0x73, 0x65
     };
     size_t expectedStunMessageLength = sizeof( expectedStunMessage );
@@ -188,8 +210,8 @@ void test_StunSerializer_AddAttributeErrorCode_Pass_( void )
     header.pTransactionId = &( transactionId[ 0 ] );
 
     result = StunSerializer_Init( &( ctx ),
-                                  &( buffer[0] ),
-                                  MAX_BUFFER_LENGTH,
+                                  pStunMessageBuffer,
+                                  STUN_MESSAGE_BUFFER_LENGTH,
                                   &( header ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
@@ -197,24 +219,22 @@ void test_StunSerializer_AddAttributeErrorCode_Pass_( void )
 
     result = StunSerializer_AddAttributeErrorCode( &( ctx ),
                                                    errorCode,
-                                                   &( errorPhrase[0] ),
+                                                   &( errorPhrase[ 0 ] ),
                                                    errorPhraseLength );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
     result = StunSerializer_Finalize( &( ctx ),
-                                      &( expectedLength ) );
+                                      &( stunMessageLength ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
-
-    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedStunMessage,
-                                   buffer,
+    TEST_ASSERT_EQUAL( expectedStunMessageLength,
+                       stunMessageLength );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedStunMessage[ 0 ] ),
+                                   pStunMessageBuffer,
                                    expectedStunMessageLength );
-
-    TEST_ASSERT_EQUAL( expectedLength,
-                       expectedStunMessageLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -231,7 +251,7 @@ void test_StunSerializer_AddAttributeErrorCode_NullContext( void )
 
     result = StunSerializer_AddAttributeErrorCode( NULL,
                                                    errorCode,
-                                                   &( errorPhrase[0] ),
+                                                   &( errorPhrase[ 0 ] ),
                                                    errorPhraseLength );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
@@ -248,19 +268,18 @@ void test_StunSerializer_AddAttributeErrorCode_NullErrorPhrase( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t buffer[ MAX_BUFFER_LENGTH ] = { 0 };
-    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
-                                                                   0x78, 0x9A, 0xBC,
-                                                                   0xDE, 0xF0, 0xAB,
-                                                                   0xCD, 0xEF, 0xA5 };
     uint16_t errorCode = 0x0600;
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
+    {
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
 
     header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
     header.pTransactionId = &( transactionId[ 0 ] );
 
     result = StunSerializer_Init( &( ctx ),
-                                  &( buffer[0] ),
-                                  MAX_BUFFER_LENGTH,
+                                  pStunMessageBuffer,
+                                  STUN_MESSAGE_BUFFER_LENGTH,
                                   &( header ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
@@ -285,20 +304,19 @@ void test_StunSerializer_AddAttributeErrorCode_ZeroErrorPhraseLength( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t buffer[ MAX_BUFFER_LENGTH ] = { 0 };
-    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
-                                                                   0x78, 0x9A, 0xBC,
-                                                                   0xDE, 0xF0, 0xAB,
-                                                                   0xCD, 0xEF, 0xA5 };
     const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
     uint16_t errorCode = 0x0600;
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
+    {
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
 
     header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
     header.pTransactionId = &( transactionId[ 0 ] );
 
     result = StunSerializer_Init( &( ctx ),
-                                  &( buffer[0] ),
-                                  MAX_BUFFER_LENGTH,
+                                  pStunMessageBuffer,
+                                  STUN_MESSAGE_BUFFER_LENGTH,
                                   &( header ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
@@ -316,49 +334,66 @@ void test_StunSerializer_AddAttributeErrorCode_ZeroErrorPhraseLength( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate StunSerializer_AddAttributeErrorCode when pCtx->pStart is null.
+ * @brief Validate StunSerializer_AddAttributeErrorCode when buffer is null.
  */
-void test_StunSerializer_AddAttributeErrorCode_pStartNull( void )
+void test_StunSerializer_AddAttributeErrorCode_BufferNull( void )
 {
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t buffer[ MAX_BUFFER_LENGTH ] = { 0 };
-    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
-                                                                   0x78, 0x9A, 0xBC,
-                                                                   0xDE, 0xF0, 0xAB,
-                                                                   0xCD, 0xEF, 0xA5 };
     const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
-    uint16_t errorPhraseLength = sizeof( errorPhrase );
+    uint16_t errorPhraseLength = strlen( ( const char * ) errorPhrase );;
     uint16_t errorCode = 0x0600;
-    size_t expectedLength;
+    size_t stunMessageLength;
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
+    {
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
+    uint8_t expectedStunMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 20 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x14,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute Type = Error Code (0x0009), Attribute Length = 16 (2 reserved bytes,
+         * 2 byte error code and 12 byte error phrase). */
+        0x00, 0x09, 0x00, 0x10,
+        /* Reserved = 0x0000, Error Code = 0x0600. */
+        0x00, 0x00, 0x06, 0x00,
+        /* Error Phrase. */
+        0x45, 0x72, 0x72, 0x6F, 0x72, 0x20, 0x50, 0x68, 0x72, 0x61, 0x73, 0x65
+    };
+    size_t expectedStunMessageLength = sizeof( expectedStunMessage );
 
     header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
     header.pTransactionId = &( transactionId[ 0 ] );
 
     result = StunSerializer_Init( &( ctx ),
-                                  &( buffer[0] ),
-                                  MAX_BUFFER_LENGTH,
+                                  NULL,
+                                  STUN_MESSAGE_BUFFER_LENGTH,
                                   &( header ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
-    ctx.pStart = NULL; /* Set pCtx->pStart to NULL */
-
     result = StunSerializer_AddAttributeErrorCode( &( ctx ),
                                                    errorCode,
-                                                   &( errorPhrase[0] ),
+                                                   &( errorPhrase[ 0 ] ),
                                                    errorPhraseLength );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
     result = StunSerializer_Finalize( &( ctx ),
-                                      &( expectedLength ) );
+                                      &( stunMessageLength ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
+    /* We should be able to get the correct length of the STUN message. */
+    TEST_ASSERT_EQUAL( expectedStunMessageLength,
+                       stunMessageLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -371,23 +406,23 @@ void test_StunSerializer_AddAttributeErrorCode_OutOfMemory( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t buffer[ 20 ] = { 0 };
-    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
-                                                                   0x78, 0x9A, 0xBC,
-                                                                   0xDE, 0xF0, 0xAB,
-                                                                   0xCD, 0xEF, 0xA5 };
     const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
     uint16_t errorPhraseLength = strlen( ( const char * ) errorPhrase );
     uint16_t errorCode = 0x0600;
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
+    {
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
 
     header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
     header.pTransactionId = &( transactionId[ 0 ] );
 
-    /* Passing a limited buffer length of 20 bytes (equal to the fixed length of the header)
-       to intentionally trigger an out-of-memory error when attempting to add the error code attribute. */
-
+    /* Passing a limited buffer of length 20 bytes (just enough to fit the STUN
+     * header and not enough to fit the error attribute) to intentionally
+     * trigger an out-of-memory error when attempting to add the error code
+     * attribute. */
     result = StunSerializer_Init( &( ctx ),
-                                  &( buffer[0] ),
+                                  pStunMessageBuffer,
                                   20,
                                   &( header ) );
 
@@ -396,7 +431,7 @@ void test_StunSerializer_AddAttributeErrorCode_OutOfMemory( void )
 
     result = StunSerializer_AddAttributeErrorCode( &( ctx ),
                                                    errorCode,
-                                                   &( errorPhrase[0] ),
+                                                   &( errorPhrase[ 0 ] ),
                                                    errorPhraseLength );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OUT_OF_MEMORY,
@@ -406,35 +441,35 @@ void test_StunSerializer_AddAttributeErrorCode_OutOfMemory( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate StunSerializer_AddAttributeErrorCode in case of short error phrase.
+ * @brief Validate StunSerializer_AddAttributeErrorCode in case of error phrase with padding.
  */
-void test_StunSerializer_AddAttributeErrorCode_Short( void )
+void test_StunSerializer_AddAttributeErrorCode_ErrorPhraseWithPadding( void )
 {
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t buffer[ MAX_BUFFER_LENGTH ] = { 0 };
-    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
-                                                                   0x78, 0x9A, 0xBC,
-                                                                   0xDE, 0xF0, 0xAB,
-                                                                   0xCD, 0xEF, 0xA5 };
     const uint8_t * errorPhrase = ( const uint8_t * ) "Short";
     uint16_t errorPhraseLength = strlen( ( const char * ) errorPhrase );
     uint16_t errorCode = 0x0600;
-    size_t expectedLength;
+    size_t stunMessageLength;
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
+    {
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
     uint8_t expectedStunMessage[] =
     {
-        /* Message Type = STUN Binding Request, Message Length = 20. */
+        /* Message Type = STUN Binding Request, Message Length = 20 (excluding 20 bytes header). */
         0x00, 0x01, 0x00, 0x10,
         /* Magic cookie. */
         0x21, 0x12, 0xA4, 0x42,
         /* Transaction ID. */
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
-        /* Attribute Type = Error Code, Attribute Length = 20 */
+        /* Attribute Type = Error Code (0x0009), Attribute Length = 9 (2 reserved bytes,
+         * 2 byte error code and 5 byte error phrase). */
         0x00, 0x09, 0x00, 0x09,
-        /* Reserved = 0, Error Code = 600 */
+        /* Reserved = 0x0000, Error Code = 0x0600. */
         0x00, 0x00, 0x06, 0x00,
-        /* Error Phrase */
+        /* Error Phrase - last 3 bytes are padding to ensure word alignment. */
         0x53, 0x68, 0x6F, 0x72, 0x74, 0x00, 0x00, 0x00
     };
     size_t expectedStunMessageLength = sizeof( expectedStunMessage );
@@ -443,8 +478,8 @@ void test_StunSerializer_AddAttributeErrorCode_Short( void )
     header.pTransactionId = &( transactionId[ 0 ] );
 
     result = StunSerializer_Init( &( ctx ),
-                                  &( buffer[0] ),
-                                  MAX_BUFFER_LENGTH,
+                                  pStunMessageBuffer,
+                                  STUN_MESSAGE_BUFFER_LENGTH,
                                   &( header ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
@@ -452,25 +487,22 @@ void test_StunSerializer_AddAttributeErrorCode_Short( void )
 
     result = StunSerializer_AddAttributeErrorCode( &( ctx ),
                                                    errorCode,
-                                                   &( errorPhrase[0] ),
+                                                   &( errorPhrase[ 0 ] ),
                                                    errorPhraseLength );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
     result = StunSerializer_Finalize( &( ctx ),
-                                      &( expectedLength ) );
+                                      &( stunMessageLength ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
-
-    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedStunMessage,
-                                   buffer,
+    TEST_ASSERT_EQUAL( expectedStunMessageLength,
+                       stunMessageLength );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedStunMessage [ 0 ] ),
+                                   pStunMessageBuffer,
                                    expectedStunMessageLength );
-
-    TEST_ASSERT_EQUAL( expectedLength,
-                       expectedStunMessageLength );
 }
 
 /*-----------------------------------------------------------*/
-


### PR DESCRIPTION
*Description of changes:*

This PR is for adding additional unit tests to improve coverage, by thoroughly testing various STUN API's .

The following test cases have been added:

-test_StunSerializer_AddAttributeErrorCode_Pass_
-test_StunSerializer_AddAttributeErrorCode_NullContext
-test_StunSerializer_AddAttributeErrorCode_NullErrorPhrase
-test_StunSerializer_AddAttributeErrorCode_ZeroErrorPhraseLength
-test_StunSerializer_AddAttributeErrorCode_pStartNull
-test_StunSerializer_AddAttributeErrorCode_OutOfMemory
-test_StunSerializer_AddAttributeErrorCode_Short

*Test Steps:*
```
cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build && ctest -V 
make coverage
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
