### PR TITLE
Add more unit-tests for stun_deserializer.c file

### DIFF
--- a/source/include/stun_data_types.h
+++ b/source/include/stun_data_types.h
@@ -104,7 +104,9 @@
 #define STUN_ALIGN_SIZE_TO_WORD( size )                 ( ( ( size ) + 0x3 ) & ~( 0x3 ) )
 #define STUN_REMAINING_LENGTH( pCtx )                   ( ( pCtx )->totalLength - ( pCtx )->currentIndex )
 #define STUN_ATTRIBUTE_TOTAL_LENGTH( valueLength )      ( valueLength + STUN_ATTRIBUTE_HEADER_LENGTH )
-#define STUN_GET_ERROR( class, code )                   ( ( uint16_t ) ( ( ( uint8_t ) ( class ) ) * 100 + ( uint8_t ) ( code ) ) )
+#define STUN_GET_ERROR( class, number )                 ( ( uint16_t ) ( ( ( uint8_t ) ( class ) ) * 100 + ( uint8_t ) ( number ) ) )
+#define STUN_GET_ERROR_CLASS( errorCode )               ( ( uint8_t ) ( ( errorCode ) / 100 ) )
+#define STUN_GET_ERROR_NUMBER( errorCode )              ( ( uint8_t ) ( ( errorCode ) % 100 ) )
 
 /* IP address macros. */
 #define STUN_ADDRESS_IPv4           0x01

--- a/source/stun_serializer.c
+++ b/source/stun_serializer.c
@@ -421,10 +421,12 @@ StunResult_t StunSerializer_AddAttributeErrorCode( StunContext_t * pCtx,
             STUN_WRITE_UINT16( &( pCtx->pStart[ pCtx->currentIndex + STUN_ATTRIBUTE_HEADER_VALUE_OFFSET ] ),
                                reserved );
 
-            STUN_WRITE_UINT16( &( pCtx->pStart[ pCtx->currentIndex +
-                                                STUN_ATTRIBUTE_HEADER_VALUE_OFFSET +
-                                                STUN_ATTRIBUTE_ERROR_CODE_CLASS_OFFSET ] ),
-                               errorCode );
+            pCtx->pStart[ pCtx->currentIndex +
+                          STUN_ATTRIBUTE_HEADER_VALUE_OFFSET +
+                          STUN_ATTRIBUTE_ERROR_CODE_CLASS_OFFSET ] = STUN_GET_ERROR_CLASS( errorCode );
+            pCtx->pStart[ pCtx->currentIndex +
+                          STUN_ATTRIBUTE_HEADER_VALUE_OFFSET +
+                          STUN_ATTRIBUTE_ERROR_CODE_NUMBER_OFFSET ] = STUN_GET_ERROR_NUMBER( errorCode );
 
             memcpy( ( void * ) &( pCtx->pStart[ pCtx->currentIndex +
                                                 STUN_ATTRIBUTE_HEADER_VALUE_OFFSET +

--- a/test/unit-test/stun_deserializer/stun_deserializer_utest.c
+++ b/test/unit-test/stun_deserializer/stun_deserializer_utest.c
@@ -32,11 +32,11 @@ void test_StunDeserializer_Init_Pass( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] = { 0x12, 0x34, 0x56,
-                                                                   0x78, 0x9A, 0xBC,
-                                                                   0xDE, 0xF0, 0xAB,
-                                                                   0xCD, 0xEF, 0xA5 };
-    uint8_t serializedHeader[] =
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
+    {
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
+    uint8_t serializedMessage[] =
     {
         /* Message Type = STUN Binding Request, Message Length = 0x00 (excluding 20 bytes header). */
         0x00, 0x01, 0x00, 0x00,
@@ -45,18 +45,18 @@ void test_StunDeserializer_Init_Pass( void )
         /* Transaction ID. */
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
     };
-    size_t stunMessageLength = sizeof( serializedHeader );
+    size_t serializedMessageLength = sizeof( serializedMessage );
 
     result = StunDeserializer_Init( &( ctx ),
-                                    &( serializedHeader[ 0 ] ),
-                                    stunMessageLength,
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
                                     &( header ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL( &( serializedHeader[ 0 ] ),
+    TEST_ASSERT_EQUAL( &( serializedMessage[ 0 ] ),
                        ctx.pStart );
-    TEST_ASSERT_EQUAL( stunMessageLength,
+    TEST_ASSERT_EQUAL( serializedMessageLength,
                        ctx.totalLength );
     TEST_ASSERT_EQUAL( STUN_HEADER_LENGTH,
                        ctx.currentIndex );
@@ -131,7 +131,7 @@ void test_StunDeserializer_Init_MagicCookieMismatch( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t serializedHeader[] =
+    uint8_t serializedMessage[] =
     {
         /* Message Type = STUN Binding Request, Message Length = 0x00. */
         0x00, 0x01, 0x00, 0x00,
@@ -140,32 +140,15 @@ void test_StunDeserializer_Init_MagicCookieMismatch( void )
         /* Transaction ID. */
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
     };
-    size_t stunMessageLength = sizeof( serializedHeader );
+    size_t serializedMessageLength = sizeof( serializedMessage );
 
     result = StunDeserializer_Init( &( ctx ),
-                                    &( serializedHeader[ 0 ] ),
-                                    stunMessageLength,
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
                                     &( header ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_MAGIC_COOKIE_MISMATCH,
                        result );
-    TEST_ASSERT_EQUAL( &( serializedHeader[ 0 ] ),
-                       ctx.pStart );
-    TEST_ASSERT_EQUAL( stunMessageLength,
-                       ctx.totalLength );
-    TEST_ASSERT_EQUAL( 0,
-                       ctx.currentIndex );
-    TEST_ASSERT_EQUAL( 0,
-                       ctx.attributeFlag );
-    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint16Fn );
-    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint32Fn );
-    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint64Fn );
-    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint16Fn );
-    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint32Fn );
-    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint64Fn );
-    TEST_ASSERT_EQUAL( STUN_MESSAGE_TYPE_BINDING_REQUEST,
-                       header.messageType );
-    TEST_ASSERT_NULL( header.pTransactionId );
 }
 
 /*-----------------------------------------------------------*/
@@ -179,7 +162,7 @@ void test_StunDeserializer_Init_InvalidMessageLength( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t serializedHeader[ STUN_HEADER_LENGTH ] =
+    uint8_t serializedMessage[ STUN_HEADER_LENGTH ] =
     {
         /* Message Type = STUN Binding Request, Message Length = 0x00. */
         0x00, 0x01, 0x00, 0x00,
@@ -188,33 +171,16 @@ void test_StunDeserializer_Init_InvalidMessageLength( void )
         /* Transaction ID. */
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
     };
-    size_t stunMessageLength = STUN_HEADER_LENGTH + 0x70; /* 0x70 is not the payload length
-                                                           * as specified in the header. */
+    size_t serializedMessageLength = STUN_HEADER_LENGTH + 0x70; /* 0x70 is not the payload length
+                                                                 * as specified in the header. */
 
     result = StunDeserializer_Init( &( ctx ),
-                                    &( serializedHeader[ 0 ] ),
-                                    stunMessageLength,
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
                                     &( header ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_INVALID_MESSAGE_LENGTH,
                        result );
-    TEST_ASSERT_EQUAL( &( serializedHeader[ 0 ] ),
-                       ctx.pStart );
-    TEST_ASSERT_EQUAL( stunMessageLength,
-                       ctx.totalLength );
-    TEST_ASSERT_EQUAL( 0,
-                       ctx.currentIndex );
-    TEST_ASSERT_EQUAL( 0,
-                       ctx.attributeFlag );
-    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint16Fn );
-    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint32Fn );
-    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint64Fn );
-    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint16Fn );
-    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint32Fn );
-    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint64Fn );
-    TEST_ASSERT_EQUAL( STUN_MESSAGE_TYPE_BINDING_REQUEST,
-                       header.messageType );
-    TEST_ASSERT_NULL( header.pTransactionId );
 }
 
 /*-----------------------------------------------------------*/
@@ -228,7 +194,12 @@ void test_StunDeserializer_GetNextAttribute_IceControlled( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t serializedHeader[] =
+    StunAttribute_t attribute = { 0 };
+    uint8_t * errorPhrase = NULL;
+    uint16_t errorPhraseLength, errorCode, channelNumber;
+    uint64_t iceControlled;
+    uint32_t lifetime, numAttributes = 0;;
+    uint8_t serializedMessage[] =
     {
         /* Message Type = STUN Binding Request, Message Length = 0x30 (excluding 20 bytes header). */
         0x00, 0x01, 0x00, 0x30,
@@ -239,9 +210,9 @@ void test_StunDeserializer_GetNextAttribute_IceControlled( void )
         /* Attribute Type = Error Code (0x0009), Attribute Length = 16 (2 reserved bytes,
          * 2 byte error code and 12 byte error phrase). */
         0x00, 0x09, 0x00, 0x10,
-        /* Reserved = 0x0000, Error Code = 0x0600. */
+        /* Reserved = 0x0000, Error Class = 6, Error Number = 0 (Error Code = 600). */
         0x00, 0x00, 0x06, 0x00,
-        /* Error Phrase. */
+        /* Error Phrase = "Error Phrase". */
         0x45, 0x72, 0x72, 0x6F,
         0x72, 0x20, 0x50, 0x68,
         0x72, 0x61, 0x73, 0x65,
@@ -259,16 +230,11 @@ void test_StunDeserializer_GetNextAttribute_IceControlled( void )
         0x12, 0x34, 0x56, 0x78,
         0x90, 0xAB, 0xCD, 0xEF,
     };
-    size_t stunMessageLength = sizeof( serializedHeader );
-    StunAttribute_t attribute = { 0 };
-    uint8_t * errorPhrase = NULL;
-    uint16_t errorPhraseLength, errorCode, channelNumber;
-    uint64_t iceControlled;
-    uint32_t lifetime;
+    size_t serializedMessageLength = sizeof( serializedMessage );
 
     result = StunDeserializer_Init( &( ctx ),
-                                    serializedHeader,
-                                    stunMessageLength,
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
                                     &( header ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
@@ -284,73 +250,78 @@ void test_StunDeserializer_GetNextAttribute_IceControlled( void )
 
         if( result == STUN_RESULT_OK )
         {
+            numAttributes++;
+
             switch( attribute.attributeType )
             {
-
-            case STUN_ATTRIBUTE_TYPE_ERROR_CODE:
-                result = StunDeserializer_ParseAttributeErrorCode( &( attribute ),
-                                                                   &( errorCode ),
-                                                                   &( errorPhrase ),
-                                                                   &( errorPhraseLength ) );
-
-                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
-                                   result );
-
-                TEST_ASSERT_EQUAL( 600,
-                                   errorCode );
-
-                TEST_ASSERT_EQUAL_STRING_LEN( "Error Phrase",
-                                              &( errorPhrase [0] ),
-                                              errorPhraseLength );
+                case STUN_ATTRIBUTE_TYPE_ERROR_CODE:
+                {
+                    result = StunDeserializer_ParseAttributeErrorCode( &( attribute ),
+                                                                       &( errorCode ),
+                                                                       &( errorPhrase ),
+                                                                       &( errorPhraseLength ) );
+                    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                       result );
+                    TEST_ASSERT_EQUAL( 600,
+                                       errorCode );
+                    TEST_ASSERT_EQUAL_STRING_LEN( "Error Phrase",
+                                                  &( errorPhrase [ 0 ] ),
+                                                  errorPhraseLength );
+                }
                 break;
 
-            case STUN_ATTRIBUTE_TYPE_CHANNEL_NUMBER:
-                result = StunDeserializer_ParseAttributeChannelNumber( &( ctx ),
-                                                                       &( attribute ),
-                                                                       &( channelNumber ) );
+                case STUN_ATTRIBUTE_TYPE_CHANNEL_NUMBER:
+                {
+                    result = StunDeserializer_ParseAttributeChannelNumber( &( ctx ),
+                                                                           &( attribute ),
+                                                                           &( channelNumber ) );
 
-                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
-                                   result );
-
-                TEST_ASSERT_EQUAL( 0x1234,
-                                   channelNumber );
+                    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                       result );
+                    TEST_ASSERT_EQUAL( 0x1234,
+                                       channelNumber );
+                }
                 break;
 
-            case STUN_ATTRIBUTE_TYPE_LIFETIME:
-                result = StunDeserializer_ParseAttributeLifetime( &( ctx ),
-                                                                  &( attribute ),
-                                                                  &( lifetime ) );
+                case STUN_ATTRIBUTE_TYPE_LIFETIME:
+                {
+                    result = StunDeserializer_ParseAttributeLifetime( &( ctx ),
+                                                                      &( attribute ),
+                                                                      &( lifetime ) );
 
-                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
-                                   result );
-
-                TEST_ASSERT_EQUAL( 0x0000EA60,
-                                   lifetime );
+                    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                       result );
+                    TEST_ASSERT_EQUAL( 0x0000EA60,
+                                       lifetime );
+                }
                 break;
 
-            case STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED:
-                result = StunDeserializer_ParseAttributeIceControlled( &( ctx ),
-                                                                       &( attribute ),
-                                                                       &( iceControlled ) );
+                case STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED:
+                {
+                    result = StunDeserializer_ParseAttributeIceControlled( &( ctx ),
+                                                                           &( attribute ),
+                                                                           &( iceControlled ) );
 
-                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
-                                   result );
-
-                TEST_ASSERT_EQUAL( 0x1234567890ABCDEF,
-                                   iceControlled );
+                    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                       result );
+                    TEST_ASSERT_EQUAL( 0x1234567890ABCDEF,
+                                       iceControlled );
+                }
                 break;
 
-            default:
-                TEST_FAIL_MESSAGE( "Unexpected attribute type" );
+                default:
+                {
+                    TEST_FAIL_MESSAGE( "Unexpected attribute type!" );
+                }
                 break;
             }
         }
-
     }
 
+    TEST_ASSERT_EQUAL( 4,
+                       numAttributes );
     TEST_ASSERT_EQUAL( STUN_RESULT_NO_MORE_ATTRIBUTE_FOUND,
                        result );
-
 }
 
 /*-----------------------------------------------------------*/
@@ -363,9 +334,13 @@ void test_StunDeserializer_GetNextAttribute_IceControlling( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint8_t serializedHeader[] =
+    StunAttribute_t attribute = { 0 };
+    uint32_t priority, changeFlag;
+    uint32_t crc32Fingerprint, numAttributes = 0;
+    uint64_t iceControlling;
+    uint8_t serializedMessage[] =
     {
-        /* Message Type = STUN Binding Request, Message Length = 0x20 (excluding 20 bytes header). */
+        /* Message Type = STUN Binding Request, Message Length = 0x24 (excluding 20 bytes header). */
         0x00, 0x01, 0x00, 0x24,
         /* Magic cookie. */
         0x21, 0x12, 0xA4, 0x42,
@@ -388,15 +363,11 @@ void test_StunDeserializer_GetNextAttribute_IceControlling( void )
         /* Attribute Value: 0x078E383F (Obtained from XOR of 0x54DA6D71 and STUN_ATTRIBUTE_FINGERPRINT_XOR_VALUE). */
         0x07, 0x8E, 0x38, 0x3F,
     };
-    size_t stunMessageLength = sizeof( serializedHeader );
-    StunAttribute_t attribute = { 0 };
-    uint32_t priority, changeFlag;
-    uint32_t crc32Fingerprint;
-    uint64_t iceControlling;
+    size_t serializedMessageLength = sizeof( serializedMessage );
 
     result = StunDeserializer_Init( &( ctx ),
-                                    serializedHeader,
-                                    stunMessageLength,
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
                                     &( header ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
@@ -412,62 +383,75 @@ void test_StunDeserializer_GetNextAttribute_IceControlling( void )
 
         if( result == STUN_RESULT_OK )
         {
+            numAttributes++;
+
             switch( attribute.attributeType )
             {
-            case STUN_ATTRIBUTE_TYPE_CHANGE_REQUEST:
-                result = StunDeserializer_ParseAttributeChangeRequest( &( ctx ),
-                                                                       &( attribute ),
-                                                                       &( changeFlag ) );
+                case STUN_ATTRIBUTE_TYPE_CHANGE_REQUEST:
+                {
+                    result = StunDeserializer_ParseAttributeChangeRequest( &( ctx ),
+                                                                           &( attribute ),
+                                                                           &( changeFlag ) );
 
-                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
-                                   result );
-
-                TEST_ASSERT_EQUAL( 0x00000004,
-                                   changeFlag );
+                    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                       result );
+                    TEST_ASSERT_EQUAL( 0x00000004,
+                                       changeFlag );
+                }
                 break;
 
-            case STUN_ATTRIBUTE_TYPE_PRIORITY:
-                result = StunDeserializer_ParseAttributePriority( &( ctx ),
-                                                                  &( attribute ),
-                                                                  &( priority ) );
+                case STUN_ATTRIBUTE_TYPE_PRIORITY:
+                {
+                    result = StunDeserializer_ParseAttributePriority( &( ctx ),
+                                                                      &( attribute ),
+                                                                      &( priority ) );
 
-                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
-                                   result );
-
-                TEST_ASSERT_EQUAL( 0x6E000100,
-                                   priority );
+                    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                       result );
+                    TEST_ASSERT_EQUAL( 0x6E000100,
+                                       priority );
+                }
                 break;
 
-            case STUN_ATTRIBUTE_TYPE_ICE_CONTROLLING:
-                result = StunDeserializer_ParseAttributeIceControlling( &( ctx ),
-                                                                        &( attribute ),
-                                                                        &( iceControlling ) );
+                case STUN_ATTRIBUTE_TYPE_ICE_CONTROLLING:
+                {
+                    result = StunDeserializer_ParseAttributeIceControlling( &( ctx ),
+                                                                            &( attribute ),
+                                                                            &( iceControlling ) );
 
-                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
-                                   result );
-
-                TEST_ASSERT_EQUAL( 0x0123456789ABCDEF,
-                                   iceControlling );
+                    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                       result );
+                    TEST_ASSERT_EQUAL( 0x0123456789ABCDEF,
+                                       iceControlling );
+                }
                 break;
 
-            case STUN_ATTRIBUTE_TYPE_FINGERPRINT:
-                result = StunDeserializer_ParseAttributeFingerprint( &( ctx ),
-                                                                     &( attribute ),
-                                                                     &( crc32Fingerprint ) );
-                                                                     
-                TEST_ASSERT_EQUAL( 0x54DA6D71,
-                                   crc32Fingerprint );
+                case STUN_ATTRIBUTE_TYPE_FINGERPRINT:
+                {
+                    result = StunDeserializer_ParseAttributeFingerprint( &( ctx ),
+                                                                         &( attribute ),
+                                                                         &( crc32Fingerprint ) );
+
+                    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                       result );
+                    TEST_ASSERT_EQUAL( 0x54DA6D71,
+                                       crc32Fingerprint );
+                }
                 break;
 
-            default:
-                TEST_FAIL_MESSAGE( "Unexpected attribute type" );
+                default:
+                {
+                    TEST_FAIL_MESSAGE( "Unexpected attribute type!" );
+                }
                 break;
-
             }
         }
-
     }
 
+    TEST_ASSERT_EQUAL( 4,
+                       numAttributes );
     TEST_ASSERT_EQUAL( STUN_RESULT_NO_MORE_ATTRIBUTE_FOUND,
                        result );
 }
+
+/*-----------------------------------------------------------*/

--- a/test/unit-test/stun_deserializer/stun_deserializer_utest.c
+++ b/test/unit-test/stun_deserializer/stun_deserializer_utest.c
@@ -36,17 +36,16 @@ void test_StunDeserializer_Init_Pass( void )
                                                                    0x78, 0x9A, 0xBC,
                                                                    0xDE, 0xF0, 0xAB,
                                                                    0xCD, 0xEF, 0xA5 };
-    uint8_t serializedHeader[ STUN_HEADER_LENGTH ] =
+    uint8_t serializedHeader[] =
     {
-        /* Message Type = STUN Binding Request, Message Length = 0x80. */
-        0x00, 0x01, 0x00, 0x80,
+        /* Message Type = STUN Binding Request, Message Length = 0x00 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x00,
         /* Magic cookie. */
         0x21, 0x12, 0xA4, 0x42,
         /* Transaction ID. */
-        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
     };
-    size_t stunMessageLength = STUN_HEADER_LENGTH + 0x80; /* 0x80 is the payload length
-                                                           * as specified in the header. */
+    size_t stunMessageLength = sizeof( serializedHeader );
 
     result = StunDeserializer_Init( &( ctx ),
                                     &( serializedHeader[ 0 ] ),
@@ -122,3 +121,353 @@ void test_StunDeserializer_Init_BadParams( void )
 }
 
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_Init incase of Magic Cookie Mismatch.
+ */
+
+void test_StunDeserializer_Init_MagicCookieMismatch( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t serializedHeader[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x00. */
+        0x00, 0x01, 0x00, 0x00,
+        /* Intentionally wrong Magic cookie. */
+        0x21, 0x13, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
+    size_t stunMessageLength = sizeof( serializedHeader );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedHeader[ 0 ] ),
+                                    stunMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_MAGIC_COOKIE_MISMATCH,
+                       result );
+    TEST_ASSERT_EQUAL( &( serializedHeader[ 0 ] ),
+                       ctx.pStart );
+    TEST_ASSERT_EQUAL( stunMessageLength,
+                       ctx.totalLength );
+    TEST_ASSERT_EQUAL( 0,
+                       ctx.currentIndex );
+    TEST_ASSERT_EQUAL( 0,
+                       ctx.attributeFlag );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint16Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint32Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint64Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint16Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint32Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint64Fn );
+    TEST_ASSERT_EQUAL( STUN_MESSAGE_TYPE_BINDING_REQUEST,
+                       header.messageType );
+    TEST_ASSERT_NULL( header.pTransactionId );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_Init incase of invalid message length.
+ */
+
+void test_StunDeserializer_Init_InvalidMessageLength( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t serializedHeader[ STUN_HEADER_LENGTH ] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x00. */
+        0x00, 0x01, 0x00, 0x00,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
+    size_t stunMessageLength = STUN_HEADER_LENGTH + 0x70; /* 0x70 is not the payload length
+                                                           * as specified in the header. */
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedHeader[ 0 ] ),
+                                    stunMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_INVALID_MESSAGE_LENGTH,
+                       result );
+    TEST_ASSERT_EQUAL( &( serializedHeader[ 0 ] ),
+                       ctx.pStart );
+    TEST_ASSERT_EQUAL( stunMessageLength,
+                       ctx.totalLength );
+    TEST_ASSERT_EQUAL( 0,
+                       ctx.currentIndex );
+    TEST_ASSERT_EQUAL( 0,
+                       ctx.attributeFlag );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint16Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint32Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.readUint64Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint16Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint32Fn );
+    TEST_ASSERT_NOT_NULL( ctx.readWriteFunctions.writeUint64Fn );
+    TEST_ASSERT_EQUAL( STUN_MESSAGE_TYPE_BINDING_REQUEST,
+                       header.messageType );
+    TEST_ASSERT_NULL( header.pTransactionId );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_GetNextAttribute incase of happy path.
+ */
+void test_StunDeserializer_GetNextAttribute_IceControlled( void )
+{
+
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t serializedHeader[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x30 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x30,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute Type = Error Code (0x0009), Attribute Length = 16 (2 reserved bytes,
+         * 2 byte error code and 12 byte error phrase). */
+        0x00, 0x09, 0x00, 0x10,
+        /* Reserved = 0x0000, Error Code = 0x0600. */
+        0x00, 0x00, 0x06, 0x00,
+        /* Error Phrase. */
+        0x45, 0x72, 0x72, 0x6F,
+        0x72, 0x20, 0x50, 0x68,
+        0x72, 0x61, 0x73, 0x65,
+        /* Attribute Type = Channel Number (0x000C), Attribute Length = 4. */
+        0x00, 0x0C, 0x00, 0x04,
+        /* Channel Number = 0x1234, Reserved = 0x0000. */
+        0x12, 0x34, 0x00, 0x00,
+        /* Attribute type = LIFETIME (0x000D), Attribute Length = 4. */
+        0x00, 0x0D, 0x00, 0x04,
+        /* Attribute Value: 0x0000EA60 (60000 seconds in hex). */
+        0x00, 0x00, 0xEA, 0x60,
+        /* Attribute type = ICE-CONTROLLED (0x8029), Attribute Length = 8. */
+        0x80, 0x29, 0x00, 0x08,
+        /* Attribute Value = 0x1234567890ABCDE. */
+        0x12, 0x34, 0x56, 0x78,
+        0x90, 0xAB, 0xCD, 0xEF,
+    };
+    size_t stunMessageLength = sizeof( serializedHeader );
+    StunAttribute_t attribute = { 0 };
+    uint8_t * errorPhrase = NULL;
+    uint16_t errorPhraseLength, errorCode, channelNumber;
+    uint64_t iceControlled;
+    uint32_t lifetime;
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    serializedHeader,
+                                    stunMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    while( result != STUN_RESULT_NO_MORE_ATTRIBUTE_FOUND )
+    {
+        TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                           result );
+
+        result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                    &( attribute ) );
+
+        if( result == STUN_RESULT_OK )
+        {
+            switch( attribute.attributeType )
+            {
+
+            case STUN_ATTRIBUTE_TYPE_ERROR_CODE:
+                result = StunDeserializer_ParseAttributeErrorCode( &( attribute ),
+                                                                   &( errorCode ),
+                                                                   &( errorPhrase ),
+                                                                   &( errorPhraseLength ) );
+
+                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                   result );
+
+                TEST_ASSERT_EQUAL( 600,
+                                   errorCode );
+
+                TEST_ASSERT_EQUAL_STRING_LEN( "Error Phrase",
+                                              &( errorPhrase [0] ),
+                                              errorPhraseLength );
+                break;
+
+            case STUN_ATTRIBUTE_TYPE_CHANNEL_NUMBER:
+                result = StunDeserializer_ParseAttributeChannelNumber( &( ctx ),
+                                                                       &( attribute ),
+                                                                       &( channelNumber ) );
+
+                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                   result );
+
+                TEST_ASSERT_EQUAL( 0x1234,
+                                   channelNumber );
+                break;
+
+            case STUN_ATTRIBUTE_TYPE_LIFETIME:
+                result = StunDeserializer_ParseAttributeLifetime( &( ctx ),
+                                                                  &( attribute ),
+                                                                  &( lifetime ) );
+
+                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                   result );
+
+                TEST_ASSERT_EQUAL( 0x0000EA60,
+                                   lifetime );
+                break;
+
+            case STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED:
+                result = StunDeserializer_ParseAttributeIceControlled( &( ctx ),
+                                                                       &( attribute ),
+                                                                       &( iceControlled ) );
+
+                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                   result );
+
+                TEST_ASSERT_EQUAL( 0x1234567890ABCDEF,
+                                   iceControlled );
+                break;
+
+            default:
+                TEST_FAIL_MESSAGE( "Unexpected attribute type" );
+                break;
+            }
+        }
+
+    }
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_NO_MORE_ATTRIBUTE_FOUND,
+                       result );
+
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_GetNextAttribute incase of happy path.
+ */
+void test_StunDeserializer_GetNextAttribute_IceControlling( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t serializedHeader[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x20 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x24,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = CHANGE-REQUEST (0x0003), Attribute Length = 4. */
+        0x00, 0x03, 0x00, 0x04,
+        /* Attribute Value: 0x00000004 (Change IP flag). */
+        0x00, 0x00, 0x00, 0x04,
+        /* Attribute Type = PRIORITY (0x0024), Attribute Length = 4. */
+        0x00, 0x24, 0x00, 0x04,
+        /* Attribute Value: 0x6E000100 (Priority = 2023406816). */
+        0x6E, 0x00, 0x01, 0x00,
+        /* Attribute Type = ICE-CONTROLLING (0x802A), Attribute Length = 8. */
+        0x80, 0x2A, 0x00, 0x08,
+        /* Attribute Value: 0x0123456789ABCDEF (ICE-CONTROLLING value). */
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+        /* Attribute type = FINGERPRINT (0x8028), Attribute Length = 4. */
+        0x80, 0x28, 0x00, 0x04,
+        /* Attribute Value: 0x078E383F (Obtained from XOR of 0x54DA6D71 and STUN_ATTRIBUTE_FINGERPRINT_XOR_VALUE). */
+        0x07, 0x8E, 0x38, 0x3F,
+    };
+    size_t stunMessageLength = sizeof( serializedHeader );
+    StunAttribute_t attribute = { 0 };
+    uint32_t priority, changeFlag;
+    uint32_t crc32Fingerprint;
+    uint64_t iceControlling;
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    serializedHeader,
+                                    stunMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    while( result != STUN_RESULT_NO_MORE_ATTRIBUTE_FOUND )
+    {
+        TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                           result );
+
+        result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                    &( attribute ) );
+
+        if( result == STUN_RESULT_OK )
+        {
+            switch( attribute.attributeType )
+            {
+            case STUN_ATTRIBUTE_TYPE_CHANGE_REQUEST:
+                result = StunDeserializer_ParseAttributeChangeRequest( &( ctx ),
+                                                                       &( attribute ),
+                                                                       &( changeFlag ) );
+
+                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                   result );
+
+                TEST_ASSERT_EQUAL( 0x00000004,
+                                   changeFlag );
+                break;
+
+            case STUN_ATTRIBUTE_TYPE_PRIORITY:
+                result = StunDeserializer_ParseAttributePriority( &( ctx ),
+                                                                  &( attribute ),
+                                                                  &( priority ) );
+
+                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                   result );
+
+                TEST_ASSERT_EQUAL( 0x6E000100,
+                                   priority );
+                break;
+
+            case STUN_ATTRIBUTE_TYPE_ICE_CONTROLLING:
+                result = StunDeserializer_ParseAttributeIceControlling( &( ctx ),
+                                                                        &( attribute ),
+                                                                        &( iceControlling ) );
+
+                TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                                   result );
+
+                TEST_ASSERT_EQUAL( 0x0123456789ABCDEF,
+                                   iceControlling );
+                break;
+
+            case STUN_ATTRIBUTE_TYPE_FINGERPRINT:
+                result = StunDeserializer_ParseAttributeFingerprint( &( ctx ),
+                                                                     &( attribute ),
+                                                                     &( crc32Fingerprint ) );
+                                                                     
+                TEST_ASSERT_EQUAL( 0x54DA6D71,
+                                   crc32Fingerprint );
+                break;
+
+            default:
+                TEST_FAIL_MESSAGE( "Unexpected attribute type" );
+                break;
+
+            }
+        }
+
+    }
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_NO_MORE_ATTRIBUTE_FOUND,
+                       result );
+}

--- a/test/unit-test/stun_serializer/stun_serializer_utest.c
+++ b/test/unit-test/stun_serializer/stun_serializer_utest.c
@@ -182,7 +182,7 @@ void test_StunSerializer_AddAttributeErrorCode_Pass( void )
     StunHeader_t header = { 0 };
     const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
     uint16_t errorPhraseLength = strlen( ( const char * ) errorPhrase );
-    uint16_t errorCode = 0x0600;
+    uint16_t errorCode = 600;
     size_t stunMessageLength;
     uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
     {
@@ -199,7 +199,7 @@ void test_StunSerializer_AddAttributeErrorCode_Pass( void )
         /* Attribute Type = Error Code (0x0009), Attribute Length = 16 (2 reserved bytes,
          * 2 byte error code and 12 byte error phrase). */
         0x00, 0x09, 0x00, 0x10,
-        /* Reserved = 0x0000, Error Code = 0x0600. */
+        /* Reserved = 0x0000, Error Class = 6, Error Number = 0 (Error Code = 600). */
         0x00, 0x00, 0x06, 0x00,
         /* Error Phrase. */
         0x45, 0x72, 0x72, 0x6F, 0x72, 0x20, 0x50, 0x68, 0x72, 0x61, 0x73, 0x65
@@ -247,7 +247,7 @@ void test_StunSerializer_AddAttributeErrorCode_NullContext( void )
     StunResult_t result;
     const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
     uint16_t errorPhraseLength = strlen( ( const char * ) errorPhrase );
-    uint16_t errorCode = 0x0600;
+    uint16_t errorCode = 600;
 
     result = StunSerializer_AddAttributeErrorCode( NULL,
                                                    errorCode,
@@ -268,7 +268,7 @@ void test_StunSerializer_AddAttributeErrorCode_NullErrorPhrase( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
-    uint16_t errorCode = 0x0600;
+    uint16_t errorCode = 600;
     uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
     {
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
@@ -305,7 +305,7 @@ void test_StunSerializer_AddAttributeErrorCode_ZeroErrorPhraseLength( void )
     StunResult_t result;
     StunHeader_t header = { 0 };
     const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
-    uint16_t errorCode = 0x0600;
+    uint16_t errorCode = 600;
     uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
     {
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
@@ -343,7 +343,7 @@ void test_StunSerializer_AddAttributeErrorCode_BufferNull( void )
     StunHeader_t header = { 0 };
     const uint8_t * errorPhrase = ( const uint8_t * ) "Error Phrase";
     uint16_t errorPhraseLength = strlen( ( const char * ) errorPhrase );;
-    uint16_t errorCode = 0x0600;
+    uint16_t errorCode = 600;
     size_t stunMessageLength;
     uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
     {
@@ -360,7 +360,7 @@ void test_StunSerializer_AddAttributeErrorCode_BufferNull( void )
         /* Attribute Type = Error Code (0x0009), Attribute Length = 16 (2 reserved bytes,
          * 2 byte error code and 12 byte error phrase). */
         0x00, 0x09, 0x00, 0x10,
-        /* Reserved = 0x0000, Error Code = 0x0600. */
+        /* Reserved = 0x0000, Error Class = 6, Error Number = 0 (Error Code = 600). */
         0x00, 0x00, 0x06, 0x00,
         /* Error Phrase. */
         0x45, 0x72, 0x72, 0x6F, 0x72, 0x20, 0x50, 0x68, 0x72, 0x61, 0x73, 0x65
@@ -450,7 +450,7 @@ void test_StunSerializer_AddAttributeErrorCode_ErrorPhraseWithPadding( void )
     StunHeader_t header = { 0 };
     const uint8_t * errorPhrase = ( const uint8_t * ) "Short";
     uint16_t errorPhraseLength = strlen( ( const char * ) errorPhrase );
-    uint16_t errorCode = 0x0600;
+    uint16_t errorCode = 600;
     size_t stunMessageLength;
     uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
     {
@@ -467,7 +467,7 @@ void test_StunSerializer_AddAttributeErrorCode_ErrorPhraseWithPadding( void )
         /* Attribute Type = Error Code (0x0009), Attribute Length = 9 (2 reserved bytes,
          * 2 byte error code and 5 byte error phrase). */
         0x00, 0x09, 0x00, 0x09,
-        /* Reserved = 0x0000, Error Code = 0x0600. */
+        /* Reserved = 0x0000, Error Class = 6, Error Number = 0 (Error Code = 600). */
         0x00, 0x00, 0x06, 0x00,
         /* Error Phrase - last 3 bytes are padding to ensure word alignment. */
         0x53, 0x68, 0x6F, 0x72, 0x74, 0x00, 0x00, 0x00


### PR DESCRIPTION
*Description of changes:*

This PR is for adding additional unit tests to improve coverage, by thoroughly testing various STUN API's .

Test Steps:

```
cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build && ctest -V 
make coverage
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
