### PR TITLE
Add more unit-tests for stun_deserializer.c file

### DIFF
--- a/test/unit-test/stun_deserializer/stun_deserializer_utest.c
+++ b/test/unit-test/stun_deserializer/stun_deserializer_utest.c
@@ -1375,7 +1375,7 @@ void test_StunDeserializer_ParseAttributeAddress_HappyPath( void )
     StunResult_t result;
     StunHeader_t header = { 0 };
     StunAttribute_t attribute = { 0 };
-    StunAttributeAddress_t address = { 0 };
+    StunAttributeAddress_t parsedAddress = { 0 };
     uint8_t expectedAddress[] = { 0x7F, 0x00, 0x00, 0x01, };
     uint8_t serializedMessage[] =
     {
@@ -1410,16 +1410,16 @@ void test_StunDeserializer_ParseAttributeAddress_HappyPath( void )
 
     result = StunDeserializer_ParseAttributeAddress( &( ctx ),
                                                      &( attribute ),
-                                                     &( address ) );
+                                                     &( parsedAddress ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( STUN_ADDRESS_IPv4,
-                       address.family );
+                       parsedAddress.family );
     TEST_ASSERT_EQUAL( 0x1234,
-                       address.port );
-    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedAddress,
-                                   address.address,
+                       parsedAddress.port );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedAddress[ 0 ] ),
+                                   &( parsedAddress.address[ 0 ] ),
                                    4 );
 }
 
@@ -1433,7 +1433,7 @@ void test_StunDeserializer_ParseAttributeAddress_NullParams( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunAttribute_t attribute = { 0 };
-    StunAttributeAddress_t address = { 0 };
+    StunAttributeAddress_t parsedAddress = { 0 };
     uint8_t attributeValue[] =
     {
         0x00, 0x01, 0x12, 0x34, 0x7F, 0x00, 0x00, 0x01,
@@ -1441,7 +1441,7 @@ void test_StunDeserializer_ParseAttributeAddress_NullParams( void )
 
     result = StunDeserializer_ParseAttributeAddress( &( ctx ),
                                                      NULL,
-                                                     &( address ) );
+                                                     &( parsedAddress ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
                        result );
@@ -1452,7 +1452,7 @@ void test_StunDeserializer_ParseAttributeAddress_NullParams( void )
 
     result = StunDeserializer_ParseAttributeAddress( &( ctx ),
                                                      &( attribute ),
-                                                     &( address ) );
+                                                     &( parsedAddress ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
                        result );
@@ -1479,7 +1479,7 @@ void test_StunDeserializer_ParseAttributeAddress_XorMapped_HappyPath( void )
     StunResult_t result;
     StunHeader_t header = { 0 };
     StunAttribute_t attribute = { 0 };
-    StunAttributeAddress_t address = { 0 };
+    StunAttributeAddress_t parsedAddress = { 0 };
     uint8_t expectedAddress[] = { 0x7F, 0x00, 0x00, 0x01 };
     uint8_t serializedMessage[] =
     {
@@ -1515,16 +1515,16 @@ void test_StunDeserializer_ParseAttributeAddress_XorMapped_HappyPath( void )
 
     result = StunDeserializer_ParseAttributeAddress( &( ctx ),
                                                      &( attribute ),
-                                                     &( address ) );
+                                                     &( parsedAddress ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( STUN_ADDRESS_IPv4,
-                       address.family );
+                       parsedAddress.family );
     TEST_ASSERT_EQUAL( 0x1234,
-                       address.port );
-    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedAddress,
-                                   address.address,
+                       parsedAddress.port );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedAddress[ 0 ] ),
+                                   &( parsedAddress.address[ 0 ] ),
                                    4 );
 }
 
@@ -1539,7 +1539,7 @@ void test_StunDeserializer_ParseAttributeAddress_XorRelayed_HappyPath( void )
     StunResult_t result;
     StunHeader_t header = { 0 };
     StunAttribute_t attribute = { 0 };
-    StunAttributeAddress_t address = { 0 };
+    StunAttributeAddress_t parsedAddress = { 0 };
     uint8_t expectedAddress[] = { 0x7F, 0x00, 0x00, 0x01 };
     uint8_t serializedMessage[] =
     {
@@ -1575,16 +1575,16 @@ void test_StunDeserializer_ParseAttributeAddress_XorRelayed_HappyPath( void )
 
     result = StunDeserializer_ParseAttributeAddress( &( ctx ),
                                                      &( attribute ),
-                                                     &( address ) );
+                                                     &( parsedAddress ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( STUN_ADDRESS_IPv4,
-                       address.family );
+                       parsedAddress.family );
     TEST_ASSERT_EQUAL( 0x1234,
-                       address.port );
-    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedAddress,
-                                   address.address,
+                       parsedAddress.port );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedAddress[ 0 ] ),
+                                   &( parsedAddress.address[ 0 ] ),
                                    4 );
 }
 
@@ -1599,7 +1599,7 @@ void test_StunDeserializer_ParseAttributeAddress_XorPeer_HappyPath( void )
     StunResult_t result;
     StunHeader_t header = { 0 };
     StunAttribute_t attribute = { 0 };
-    StunAttributeAddress_t address = { 0 };
+    StunAttributeAddress_t parsedAddress = { 0 };
     uint8_t expectedAddress[] = { 0x7F, 0x00, 0x00, 0x01 };
     uint8_t serializedMessage[] =
     {
@@ -1635,16 +1635,16 @@ void test_StunDeserializer_ParseAttributeAddress_XorPeer_HappyPath( void )
 
     result = StunDeserializer_ParseAttributeAddress( &( ctx ),
                                                      &( attribute ),
-                                                     &( address ) );
+                                                     &( parsedAddress ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( STUN_ADDRESS_IPv4,
-                       address.family );
+                       parsedAddress.family );
     TEST_ASSERT_EQUAL( 0x1234,
-                       address.port );
-    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedAddress,
-                                   address.address,
+                       parsedAddress.port );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedAddress[ 0 ] ),
+                                   &( parsedAddress.address[ 0 ] ),
                                    4 );
 }
 
@@ -1659,21 +1659,13 @@ void test_StunDeserializer_ParseAttributeAddress_IPv6_HappyPath( void )
     StunResult_t result;
     StunHeader_t header = { 0 };
     StunAttribute_t attribute = { 0 };
-    StunAttributeAddress_t address = { 0 };
-    uint8_t expectedAddress[16] =
+    StunAttributeAddress_t parsedAddress = { 0 };
+    uint8_t expectedAddress[] =
     {
         0x01, 0x13, 0xA9, 0xFA,
         0x97, 0x97, 0x56, 0x78,
         0x9A, 0xBC, 0x54, 0xDE,
         0xA8, 0xBD, 0x9C, 0x91,
-    };
-    uint8_t attributeValue[] =
-    {
-        0x00, 0x02, 0x12, 0x34,
-        0x20, 0x01, 0x0D, 0xB8,
-        0x85, 0xA3, 0x00, 0x00,
-        0x00, 0x00, 0x8A, 0x2E,
-        0x03, 0x70, 0x73, 0x34,
     };
     uint8_t serializedMessage[] =
     {
@@ -1685,8 +1677,10 @@ void test_StunDeserializer_ParseAttributeAddress_IPv6_HappyPath( void )
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
         /* Attribute type = XOR-MAPPED-ADDRESS (0x0020), Attribute Length = 20. */
         0x00, 0x20, 0x00, 0x14,
-        /* Address family = IPv6, Port = 0x1234, IP Address = 0x2001:0DB8:85A3:0000:0000:8A2E:0370:7334. */
-        0x00, 0x02, 0x12, 0x34,
+        /* Address family = IPv6, Port = 0x3326 (0x1234 XOR'd with 2 msb of cookie),
+         * IP Address = 2001:0DB8:85A3:0000:0000:8A2E:0370:7334 (0113:A9FA:9797:5678:9ABC:54DE:A8BD:9C91
+         * XOR'd with cookie and transaction ID). */
+        0x00, 0x02, 0x33, 0x26,
         0x20, 0x01, 0x0D, 0xB8,
         0x85, 0xA3, 0x00, 0x00,
         0x00, 0x00, 0x8A, 0x2E,
@@ -1702,25 +1696,26 @@ void test_StunDeserializer_ParseAttributeAddress_IPv6_HappyPath( void )
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
-    attribute.attributeType = STUN_ATTRIBUTE_TYPE_XOR_MAPPED_ADDRESS;
-    attribute.pAttributeValue = &( attributeValue[0] );
-    attribute.attributeValueLength = sizeof( attributeValue );
-
-    result = StunDeserializer_ParseAttributeAddress( &( ctx ),
-                                                     &( attribute ),
-                                                     &( address ) );
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
+    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_XOR_MAPPED_ADDRESS,
+                       attribute.attributeType );
 
+    result = StunDeserializer_ParseAttributeAddress( &( ctx ),
+                                                     &( attribute ),
+                                                     &( parsedAddress ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
     TEST_ASSERT_EQUAL( STUN_ADDRESS_IPv6,
-                       address.family );
-
-    TEST_ASSERT_EQUAL( ( 0x1234 ^ ( STUN_HEADER_MAGIC_COOKIE >> 16 ) ),
-                       address.port );
-
-    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedAddress,
-                                   address.address,
+                       parsedAddress.family );
+    TEST_ASSERT_EQUAL( 0x1234,
+                       parsedAddress.port );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedAddress[ 0 ] ),
+                                   &( parsedAddress.address[ 0 ] ),
                                    16 );
 }
 
@@ -1757,7 +1752,13 @@ void test_StunDeserializer_FindAttribute( void )
         0x6E, 0x00, 0x01, 0x00,
     };
     size_t serializedMessageLength = sizeof( serializedMessage );
-    uint8_t attributeValue[] = {0x6E, 0x00, 0x01, 0x00,};
+    uint8_t expectedAttributeValue[] =
+    {
+        /* Priority attribute value = 0x6E000100. */
+        0x6E, 0x00, 0x01, 0x00,
+    };
+    size_t expectedAttributeValueLength = sizeof( expectedAttributeValue );
+
     result = StunDeserializer_Init( &( ctx ),
                                     &( serializedMessage[ 0 ] ),
                                     serializedMessageLength,
@@ -1765,10 +1766,6 @@ void test_StunDeserializer_FindAttribute( void )
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
-
-    attribute.attributeType = STUN_ATTRIBUTE_TYPE_PRIORITY;
-    attribute.pAttributeValue = &( attributeValue[0] );
-    attribute.attributeValueLength = sizeof( attributeValue );
 
     result = StunDeserializer_FindAttribute( &( ctx ),
                                              STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED,
@@ -1783,47 +1780,24 @@ void test_StunDeserializer_FindAttribute( void )
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
-
     TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_PRIORITY,
                        attribute.attributeType );
-
-    TEST_ASSERT_EQUAL_UINT8_ARRAY( attributeValue,
+    TEST_ASSERT_EQUAL( expectedAttributeValueLength,
+                       attribute.attributeValueLength );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedAttributeValue[ 0 ] ),
                                    attribute.pAttributeValue,
-                                   sizeof( attributeValue ) );
+                                   expectedAttributeValueLength );
 }
 
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate StunDeserializer_FindAttribute in case of null attribute
+ * @brief Validate StunDeserializer_FindAttribute in case of null attribute.
  */
 void test_StunDeserializer_FindAttribute_NullAttribute( void )
 {
     StunContext_t ctx = { 0 };
     StunResult_t result;
-    StunHeader_t header = { 0 };
-    uint8_t serializedMessage[] =
-    {
-        /* Message Type = STUN Binding Request, Message Length = 0x08 (excluding 20 bytes header). */
-        0x00, 0x01, 0x00, 0x08,
-        /* Magic cookie. */
-        0x21, 0x12, 0xA4, 0x42,
-        /* Transaction ID. */
-        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
-        /* Attribute Type = PRIORITY (0x0024), Attribute Length = 4. */
-        0x00, 0x24, 0x00, 0x04,
-        /* Attribute Value: 0x6E000100 (Priority = 2023406816). */
-        0x6E, 0x00, 0x01, 0x00,
-    };
-    size_t serializedMessageLength = sizeof( serializedMessage );
-
-    result = StunDeserializer_Init( &( ctx ),
-                                    &( serializedMessage[ 0 ] ),
-                                    serializedMessageLength,
-                                    &( header ) );
-
-    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
-                       result );
 
     result = StunDeserializer_FindAttribute( &( ctx ),
                                              STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED,
@@ -1854,13 +1828,15 @@ void test_StunDeserializer_FindAttribute_NullContext( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate StunDeserializer_FindAttribute in case of null context->start.
+ * @brief Validate StunDeserializer_FindAttribute in case of null StunContext_t.pStart.
  */
 void test_StunDeserializer_FindAttribute_NullContextStart( void )
 {
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunAttribute_t attribute = { 0 };
+
+    ctx.pStart = NULL;
 
     result = StunDeserializer_FindAttribute( &( ctx ),
                                              STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED,
@@ -1883,8 +1859,8 @@ void test_StunDeserializer_GetNextAttribute_InvalidAttributeOrder( void )
     StunAttribute_t attribute = { 0 };
     uint8_t serializedMessage[] =
     {
-        /* Message Type = STUN Binding Request, Message Length = 0x1C (excluding 20 bytes header). */
-        0x00, 0x01, 0x00, 0x1C,
+        /* Message Type = STUN Binding Request, Message Length = 0x20 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x20,
         /* Magic cookie. */
         0x21, 0x12, 0xA4, 0x42,
         /* Transaction ID. */
@@ -1893,13 +1869,14 @@ void test_StunDeserializer_GetNextAttribute_InvalidAttributeOrder( void )
         0x80, 0x28, 0x00, 0x04,
         /* Attribute Value: 0x078E383F (Obtained from XOR of 0x54DA6D71 and STUN_ATTRIBUTE_FINGERPRINT_XOR_VALUE). */
         0x07, 0x8E, 0x38, 0x3F,
-        /* Attribute type = MESSAGE-INTEGRITY (0x0008), Length = 16 bytes. */
-        0x00, 0x08, 0x00, 0x10,
-        /* Attribute Value = HMAC value as computed by testHmacFxn. */
+        /* Attribute type = MESSAGE-INTEGRITY (0x0008), Length = 20 bytes. */
+        0x00, 0x08, 0x00, 0x14,
+        /* Attribute Value = 20 bytes SHA-1 HMAC value. */
         0x72, 0x64, 0x6D, 0x2F,
         0x55, 0x77, 0xF4, 0x23,
         0x73, 0x72, 0x75, 0x6C,
         0x76, 0x61, 0x74, 0x62,
+        0xAB, 0xCD, 0xDE, 0xEF,
     };
     size_t serializedMessageLength = sizeof( serializedMessage );
 
@@ -1912,21 +1889,18 @@ void test_StunDeserializer_GetNextAttribute_InvalidAttributeOrder( void )
                        result );
 
     /* First attribute is FINGERPRINT. */
-
     result = StunDeserializer_GetNextAttribute( &( ctx ),
                                                 &( attribute ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
-
     TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_FINGERPRINT,
                        attribute.attributeType );
 
     /*
-     * Next attribute is the Message-Integrity attribute.
-     * However, this is an invalid order, as Message-Integrity should come before Fingerprint.
+     * Next attribute is the Message-Integrity attribute. However, this is an
+     * invalid order, as Message-Integrity must come before Fingerprint.
      */
-
     result = StunDeserializer_GetNextAttribute( &( ctx ),
                                                 &( attribute ) );
 
@@ -1947,19 +1921,20 @@ void test_StunDeserializer_GetNextAttribute_InvalidAttributeOrder_2( void )
     StunAttribute_t attribute = { 0 };
     uint8_t serializedMessage[] =
     {
-        /* Message Type = STUN Binding Request, Message Length = 0x1C (excluding 20 bytes header). */
-        0x00, 0x01, 0x00, 0x1C,
+        /* Message Type = STUN Binding Request, Message Length = 0x20 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x20,
         /* Magic cookie. */
         0x21, 0x12, 0xA4, 0x42,
         /* Transaction ID. */
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
-        /* Attribute type = MESSAGE-INTEGRITY (0x0008), Length = 16 bytes. */
-        0x00, 0x08, 0x00, 0x10,
-        /* Attribute Value = HMAC value as computed by testHmacFxn. */
+        /* Attribute type = MESSAGE-INTEGRITY (0x0008), Length = 20 bytes. */
+        0x00, 0x08, 0x00, 0x14,
+        /* Attribute Value = 20 bytes SHA-1 HMAC value. */
         0x72, 0x64, 0x6D, 0x2F,
         0x55, 0x77, 0xF4, 0x23,
         0x73, 0x72, 0x75, 0x6C,
         0x76, 0x61, 0x74, 0x62,
+        0xAB, 0xCD, 0xDE, 0xEF,
         /* Attribute Type = PRIORITY (0x0024), Attribute Length = 4. */
         0x00, 0x24, 0x00, 0x04,
         /* Attribute Value: 0x6E000100 (Priority = 2023406816). */
@@ -1975,23 +1950,18 @@ void test_StunDeserializer_GetNextAttribute_InvalidAttributeOrder_2( void )
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
-    /* First attribute is Integrity. */
-
+    /* First attribute is Message-Integrity. */
     result = StunDeserializer_GetNextAttribute( &( ctx ),
                                                 &( attribute ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
-
     TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_MESSAGE_INTEGRITY,
                        attribute.attributeType );
 
-    /*
-     * Next attribute is the Priority attribute.
-     * However, this is an invalid order, as Priority should come before Message-Integrity.
-     * Only Fingerprint attribute can come after the Message-Integrity attribute.
-     */
-
+    /* Next attribute is the Priority. However, this is an invalid order, as
+     * Priority must come before Message-Integrity. Only Fingerprint attribute
+     * can come after the Message-Integrity attribute. */
     result = StunDeserializer_GetNextAttribute( &( ctx ),
                                                 &( attribute ) );
 
@@ -2013,19 +1983,20 @@ void test_StunDeserializer_GetNextAttribute_ValidAttributeOrder( void )
     uint32_t crc32Fingerprint;
     uint8_t serializedMessage[] =
     {
-        /* Message Type = STUN Binding Request, Message Length = 0x1C (excluding 20 bytes header). */
-        0x00, 0x01, 0x00, 0x1C,
+        /* Message Type = STUN Binding Request, Message Length = 0x20 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x20,
         /* Magic cookie. */
         0x21, 0x12, 0xA4, 0x42,
         /* Transaction ID. */
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
-        /* Attribute type = MESSAGE-INTEGRITY (0x0008), Length = 16 bytes. */
-        0x00, 0x08, 0x00, 0x10,
-        /* Attribute Value = HMAC value as computed by testHmacFxn. */
+        /* Attribute type = MESSAGE-INTEGRITY (0x0008), Length = 20 bytes. */
+        0x00, 0x08, 0x00, 0x14,
+        /* Attribute Value = 20 bytes SHA-1 HMAC value. */
         0x72, 0x64, 0x6D, 0x2F,
         0x55, 0x77, 0xF4, 0x23,
         0x73, 0x72, 0x75, 0x6C,
         0x76, 0x61, 0x74, 0x62,
+        0xAB, 0xCD, 0xDE, 0xEF,
         /* Attribute type = FINGERPRINT (0x8028), Attribute Length = 4. */
         0x80, 0x28, 0x00, 0x04,
         /* Attribute Value: 0x078E383F (Obtained from XOR of 0x54DA6D71 and STUN_ATTRIBUTE_FINGERPRINT_XOR_VALUE). */
@@ -2040,24 +2011,22 @@ void test_StunDeserializer_GetNextAttribute_ValidAttributeOrder( void )
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
+
     /* First attribute is Message-Integrity. */
     result = StunDeserializer_GetNextAttribute( &( ctx ),
                                                 &( attribute ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
-
     TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_MESSAGE_INTEGRITY,
                        attribute.attributeType );
 
-    /* Get the next attribute, which should be the Fingerprint attribute. */
-
+    /* Next attribute is Fingerprint. */
     result = StunDeserializer_GetNextAttribute( &( ctx ),
                                                 &( attribute ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
-
     TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_FINGERPRINT,
                        attribute.attributeType );
 
@@ -2067,7 +2036,6 @@ void test_StunDeserializer_GetNextAttribute_ValidAttributeOrder( void )
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
-                       
     TEST_ASSERT_EQUAL( 0x54DA6D71,
                        crc32Fingerprint );
 }
@@ -2091,13 +2059,13 @@ void test_StunDeserializer_GetNextAttribute_ZeroAttributeValueLength( void )
         0x21, 0x12, 0xA4, 0x42,
         /* Transaction ID. */
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
-        /* Attribute Type = PRIORITY (0x0024), Attribute Length is intentionally kept as 0 */
-        0x00, 0x24, 0x00, 0x00,
+        /* Attribute Type = USE-CANDIDATE (0x0025), Length = 0. */
+        0x00, 0x25, 0x00, 0x00,
     };
     size_t serializedMessageLength = sizeof( serializedMessage );
 
     result = StunDeserializer_Init( &( ctx ),
-                                    &( serializedMessage[0] ),
+                                    &( serializedMessage[ 0 ] ),
                                     serializedMessageLength,
                                     &( header ) );
 
@@ -2109,13 +2077,10 @@ void test_StunDeserializer_GetNextAttribute_ZeroAttributeValueLength( void )
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
-
-    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_PRIORITY,
+    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_USE_CANDIDATE,
                        attribute.attributeType );
-
     TEST_ASSERT_EQUAL( 0,
                        attribute.attributeValueLength );
-
     TEST_ASSERT_EQUAL( NULL,
                        attribute.pAttributeValue );
 }
@@ -2141,11 +2106,12 @@ void test_StunDeserializer_GetNextAttribute_OutOfMemory( void )
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
         /* Attribute Type = PRIORITY (0x0024), Attribute Length = 4. */
         0x00, 0x24, 0x00, 0x04,
+        /* Missing priority value. */
     };
     size_t serializedMessageLength = sizeof( serializedMessage );
 
     result = StunDeserializer_Init( &( ctx ),
-                                    &( serializedMessage[0] ),
+                                    &( serializedMessage[ 0 ] ),
                                     serializedMessageLength,
                                     &( header ) );
 

--- a/test/unit-test/stun_deserializer/stun_deserializer_utest.c
+++ b/test/unit-test/stun_deserializer/stun_deserializer_utest.c
@@ -1080,8 +1080,8 @@ void test_StunDeserializer_GetFingerprintBuffer_HappyPath( void )
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
-    result =  StunDeserializer_GetNextAttribute( &( ctx ),
-                                                 &( attribute ) );
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
@@ -1177,8 +1177,8 @@ void test_StunDeserializer_GetIntegrityBuffer_HappyPath( void )
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
-    result =  StunDeserializer_GetNextAttribute( &( ctx ),
-                                                 &( attribute ) );
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
@@ -1400,8 +1400,8 @@ void test_StunDeserializer_ParseAttributeAddress_HappyPath( void )
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
-    result =  StunDeserializer_GetNextAttribute( &( ctx ),
-                                                 &( attribute ) );
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
@@ -1505,8 +1505,8 @@ void test_StunDeserializer_ParseAttributeAddress_XorMapped_HappyPath( void )
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
-    result =  StunDeserializer_GetNextAttribute( &( ctx ),
-                                                 &( attribute ) );
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
@@ -1565,8 +1565,8 @@ void test_StunDeserializer_ParseAttributeAddress_XorRelayed_HappyPath( void )
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
-    result =  StunDeserializer_GetNextAttribute( &( ctx ),
-                                                 &( attribute ) );
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
@@ -1625,8 +1625,8 @@ void test_StunDeserializer_ParseAttributeAddress_XorPeer_HappyPath( void )
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
 
-    result =  StunDeserializer_GetNextAttribute( &( ctx ),
-                                                 &( attribute ) );
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OK,
                        result );
@@ -1649,3 +1649,429 @@ void test_StunDeserializer_ParseAttributeAddress_XorPeer_HappyPath( void )
 }
 
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_ParseAttributeAddress (IPv6 Type) incase of happy path.
+ */
+void test_StunDeserializer_ParseAttributeAddress_IPv6_HappyPath( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    StunAttributeAddress_t address = { 0 };
+    uint8_t expectedAddress[16] =
+    {
+        0x01, 0x13, 0xA9, 0xFA,
+        0x97, 0x97, 0x56, 0x78,
+        0x9A, 0xBC, 0x54, 0xDE,
+        0xA8, 0xBD, 0x9C, 0x91,
+    };
+    uint8_t attributeValue[] =
+    {
+        0x00, 0x02, 0x12, 0x34,
+        0x20, 0x01, 0x0D, 0xB8,
+        0x85, 0xA3, 0x00, 0x00,
+        0x00, 0x00, 0x8A, 0x2E,
+        0x03, 0x70, 0x73, 0x34,
+    };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x18 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x18,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = XOR-MAPPED-ADDRESS (0x0020), Attribute Length = 20. */
+        0x00, 0x20, 0x00, 0x14,
+        /* Address family = IPv6, Port = 0x1234, IP Address = 0x2001:0DB8:85A3:0000:0000:8A2E:0370:7334. */
+        0x00, 0x02, 0x12, 0x34,
+        0x20, 0x01, 0x0D, 0xB8,
+        0x85, 0xA3, 0x00, 0x00,
+        0x00, 0x00, 0x8A, 0x2E,
+        0x03, 0x70, 0x73, 0x34,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    attribute.attributeType = STUN_ATTRIBUTE_TYPE_XOR_MAPPED_ADDRESS;
+    attribute.pAttributeValue = &( attributeValue[0] );
+    attribute.attributeValueLength = sizeof( attributeValue );
+
+    result = StunDeserializer_ParseAttributeAddress( &( ctx ),
+                                                     &( attribute ),
+                                                     &( address ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ADDRESS_IPv6,
+                       address.family );
+    TEST_ASSERT_EQUAL( ( 0x1234 ^ ( STUN_HEADER_MAGIC_COOKIE >> 16 ) ),
+                       address.port );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( expectedAddress,
+                                   address.address,
+                                   16 );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_FindAttribute in case of different attribute types.
+ *
+ * It includes the following scenarios:
+ *
+ * 1. Passing a NULL pointer for the StunAttribute_t structure, which should return
+ *    STUN_RESULT_BAD_PARAM.
+ * 2. Trying to find the STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED attribute, which is not
+ *    present in the STUN message, and expecting the function to return
+ *    STUN_RESULT_NO_ATTRIBUTE_FOUND.
+ * 3. Finding the STUN_ATTRIBUTE_TYPE_PRIORITY attribute, which is present in the
+ *    STUN message, and verifying that the function returns STUN_RESULT_OK.
+ */
+void test_StunDeserializer_FindAttribute( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x08 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x08,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute Type = PRIORITY (0x0024), Attribute Length = 4. */
+        0x00, 0x24, 0x00, 0x04,
+        /* Attribute Value: 0x6E000100 (Priority = 2023406816). */
+        0x6E, 0x00, 0x01, 0x00,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+    uint8_t attributeValue[] = {0x6E, 0x00, 0x01, 0x00,};
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunDeserializer_FindAttribute( &( ctx ),
+                                             STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED,
+                                             NULL );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
+                       result );
+
+    attribute.attributeType = STUN_ATTRIBUTE_TYPE_PRIORITY;
+    attribute.pAttributeValue = &( attributeValue[0] );
+    attribute.attributeValueLength = sizeof( attributeValue );
+
+    result = StunDeserializer_FindAttribute( &( ctx ),
+                                             STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED,
+                                             &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_NO_ATTRIBUTE_FOUND,
+                       result );
+
+    result = StunDeserializer_FindAttribute( &( ctx ),
+                                             STUN_ATTRIBUTE_TYPE_PRIORITY,
+                                             &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_FindAttribute in case of bad parameters.
+ */
+void test_StunDeserializer_FindAttribute_BadParams( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunAttribute_t attribute = { 0 };
+
+    result = StunDeserializer_FindAttribute( NULL,
+                                             STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED,
+                                             &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
+                       result );
+
+    result = StunDeserializer_FindAttribute( &( ctx ),
+                                             STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED,
+                                             &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_GetNextAttribute incase of invalid attribute order.
+ */
+void test_StunDeserializer_GetNextAttribute_InvalidAttributeOrder( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x1C (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x1C,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = FINGERPRINT (0x8028), Attribute Length = 4. */
+        0x80, 0x28, 0x00, 0x04,
+        /* Attribute Value: 0x078E383F (Obtained from XOR of 0x54DA6D71 and STUN_ATTRIBUTE_FINGERPRINT_XOR_VALUE). */
+        0x07, 0x8E, 0x38, 0x3F,
+        /* Attribute type = MESSAGE-INTEGRITY (0x0008), Length = 16 bytes. */
+        0x00, 0x08, 0x00, 0x10,
+        /* Attribute Value = HMAC value as computed by testHmacFxn. */
+        0x72, 0x64, 0x6D, 0x2F,
+        0x55, 0x77, 0xF4, 0x23,
+        0x73, 0x72, 0x75, 0x6C,
+        0x76, 0x61, 0x74, 0x62,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    /* First attribute is FINGERPRINT. */
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    /*
+     * Next attribute is the Message-Integrity attribute.
+     * However, this is an invalid order, as Message-Integrity should come before Fingerprint.
+     */
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_INVALID_ATTRIBUTE_ORDER,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_GetNextAttribute incase of invalid attribute order.
+ */
+void test_StunDeserializer_GetNextAttribute_InvalidAttributeOrder_2( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x1C (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x1C,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = MESSAGE-INTEGRITY (0x0008), Length = 16 bytes. */
+        0x00, 0x08, 0x00, 0x10,
+        /* Attribute Value = HMAC value as computed by testHmacFxn. */
+        0x72, 0x64, 0x6D, 0x2F,
+        0x55, 0x77, 0xF4, 0x23,
+        0x73, 0x72, 0x75, 0x6C,
+        0x76, 0x61, 0x74, 0x62,
+        /* Attribute Type = PRIORITY (0x0024), Attribute Length = 4. */
+        0x00, 0x24, 0x00, 0x04,
+        /* Attribute Value: 0x6E000100 (Priority = 2023406816). */
+        0x6E, 0x00, 0x01, 0x00,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    /* First attribute is Integrity. */
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    /*
+     * Next attribute is the Priority attribute.
+     * However, this is an invalid order, as Priority should come before Message-Integrity.
+     * Only Fingerprint attribute can come after the Message-Integrity attribute.
+     */
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_INVALID_ATTRIBUTE_ORDER,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_GetNextAttribute incase of valid attribute order.
+ */
+void test_StunDeserializer_GetNextAttribute_ValidAttributeOrder( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x1C (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x1C,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = MESSAGE-INTEGRITY (0x0008), Length = 16 bytes. */
+        0x00, 0x08, 0x00, 0x10,
+        /* Attribute Value = HMAC value as computed by testHmacFxn. */
+        0x72, 0x64, 0x6D, 0x2F,
+        0x55, 0x77, 0xF4, 0x23,
+        0x73, 0x72, 0x75, 0x6C,
+        0x76, 0x61, 0x74, 0x62,
+        /* Attribute type = FINGERPRINT (0x8028), Attribute Length = 4. */
+        0x80, 0x28, 0x00, 0x04,
+        /* Attribute Value: 0x078E383F (Obtained from XOR of 0x54DA6D71 and STUN_ATTRIBUTE_FINGERPRINT_XOR_VALUE). */
+        0x07, 0x8E, 0x38, 0x3F,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    /* First attribute is Message-Integrity. */
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    /* Get the next attribute, which should be the Fingerprint attribute. */
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_GetNextAttribute in case of zero attributeValueLength.
+ */
+void test_StunDeserializer_GetNextAttribute_ZeroAttributeValueLength( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x04 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x04,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute Type = PRIORITY (0x0024), Attribute Length is intentionally kept as 0 */
+        0x00, 0x24, 0x00, 0x00,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[0] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_PRIORITY,
+                       attribute.attributeType );
+    TEST_ASSERT_EQUAL( 0,
+                       attribute.attributeValueLength );
+    TEST_ASSERT_EQUAL( NULL,
+                       attribute.pAttributeValue );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_GetNextAttribute in case of out of memory.
+ */
+void test_StunDeserializer_GetNextAttribute_OutOfMemory( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x04 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x04,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute Type = PRIORITY (0x0024), Attribute Length = 4. */
+        0x00, 0x24, 0x00, 0x04,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[0] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+
+
+


### PR DESCRIPTION
*Description of changes:*

This PR is for adding additional unit tests to improve coverage, by thoroughly testing various STUN API's .

*Test Steps:*

```
cmake -S test/unit-test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build && ctest -V 
make coverage
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
