### PR TITLE
Fix critical security vulnerabilities in STUN library

### DIFF
--- a/source/include/stun_data_types.h
+++ b/source/include/stun_data_types.h
@@ -114,6 +114,7 @@
 #define STUN_ATTRIBUTE_ERROR_CODE_VALUE_STALE_NONCE     438
 
 /* Attribute value lengths. */
+#define STUN_ATTRIBUTE_VALUE_MAX_LENGTH                 512 /* Maximum for general attributes. */
 #define STUN_ATTRIBUTE_PRIORITY_VALUE_LENGTH            4 /* 32-bit priority value. */
 #define STUN_ATTRIBUTE_LIFETIME_VALUE_LENGTH            4 /* 32-bit lifetime value. */
 #define STUN_ATTRIBUTE_CHANGE_REQUEST_VALUE_LENGTH      4 /* 32-bit flag. */

--- a/source/stun_deserializer.c
+++ b/source/stun_deserializer.c
@@ -102,6 +102,10 @@ static uint8_t IsAttributeLengthValid( StunAttributeType_t attributeType,
     switch( attributeType )
     {
         case STUN_ATTRIBUTE_TYPE_MAPPED_ADDRESS:
+        case STUN_ATTRIBUTE_TYPE_RESPONSE_ADDRESS:
+        case STUN_ATTRIBUTE_TYPE_SOURCE_ADDRESS:
+        case STUN_ATTRIBUTE_TYPE_CHANGED_ADDRESS:
+        case STUN_ATTRIBUTE_TYPE_REFLECTED_FROM:
         case STUN_ATTRIBUTE_TYPE_XOR_MAPPED_ADDRESS:
         case STUN_ATTRIBUTE_TYPE_XOR_RELAYED_ADDRESS:
         case STUN_ATTRIBUTE_TYPE_XOR_PEER_ADDRESS:

--- a/source/stun_deserializer.c
+++ b/source/stun_deserializer.c
@@ -217,7 +217,7 @@ static uint8_t IsAttributeLengthValid( StunAttributeType_t attributeType,
         default:
         {
             /* For any other attribute type, the maximum length is 512 bytes. */
-            if( attributeValueLength <= 512 )
+            if( attributeValueLength <= STUN_ATTRIBUTE_VALUE_MAX_LENGTH )
             {
                 isValid = 1;
             }

--- a/source/stun_serializer.c
+++ b/source/stun_serializer.c
@@ -680,6 +680,21 @@ StunResult_t StunSerializer_AddAttributeAddress( StunContext_t * pCtx,
         result = STUN_RESULT_BAD_PARAM;
     }
 
+    if( result == STUN_RESULT_OK )
+    {
+        /* Make a local copy as the XorAddress call below updates the address. */
+        memcpy( &( localAddress ),
+                pAddress,
+                sizeof( StunAttributeAddress_t ) );
+
+        attributeValueLength = STUN_ATTRIBUTE_ADDRESS_HEADER_LENGTH +
+                               ( ( localAddress.family == STUN_ADDRESS_IPv4 ) ? STUN_IPV4_ADDRESS_SIZE :
+                                 STUN_IPV6_ADDRESS_SIZE );
+
+        result = CheckAndUpdateAttributeFlag( pCtx,
+                                              attributeType );
+    }
+
     if( ( result == STUN_RESULT_OK ) &&
         ( pCtx->pStart != NULL ) )
     {
@@ -687,24 +702,6 @@ StunResult_t StunSerializer_AddAttributeAddress( StunContext_t * pCtx,
         {
             result = STUN_RESULT_OUT_OF_MEMORY;
         }
-    }
-
-    if( result == STUN_RESULT_OK )
-    {
-        /* Make a local copy as the XorAddress call below updates the address. */
-        memcpy( &( localAddress ),
-                pAddress,
-                sizeof( StunAttributeAddress_t ) );
-    }
-
-    if( result == STUN_RESULT_OK )
-    {
-        attributeValueLength = STUN_ATTRIBUTE_ADDRESS_HEADER_LENGTH +
-                               ( ( localAddress.family == STUN_ADDRESS_IPv4 ) ? STUN_IPV4_ADDRESS_SIZE :
-                                 STUN_IPV6_ADDRESS_SIZE );
-
-        result = CheckAndUpdateAttributeFlag( pCtx,
-                                              attributeType );
     }
 
     if( ( result == STUN_RESULT_OK ) &&

--- a/source/stun_serializer.c
+++ b/source/stun_serializer.c
@@ -327,7 +327,7 @@ StunResult_t StunSerializer_Init( StunContext_t * pCtx,
     if( ( pCtx == NULL ) ||
         ( pHeader == NULL ) ||
         ( ( pBuffer != NULL ) && ( bufferLength < STUN_HEADER_LENGTH ) ) ||
-        ( ( pCtx->pStart != NULL ) && ( pHeader->pTransactionId == NULL ) ) )
+        ( ( pBuffer != NULL ) && ( pHeader->pTransactionId == NULL ) ) )
     {
         result = STUN_RESULT_BAD_PARAM;
     }
@@ -356,7 +356,6 @@ StunResult_t StunSerializer_Init( StunContext_t * pCtx,
             memcpy( ( void * ) &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_TRANSACTION_ID_OFFSET ] ),
                     ( const void * ) &( pHeader->pTransactionId[ 0 ] ),
                     STUN_HEADER_TRANSACTION_ID_LENGTH );
-
         }
 
         pCtx->currentIndex += STUN_HEADER_LENGTH;

--- a/source/stun_serializer.c
+++ b/source/stun_serializer.c
@@ -388,14 +388,13 @@ StunResult_t StunSerializer_AddAttributeErrorCode( StunContext_t * pCtx,
     {
         attributeValueLength = STUN_ATTRIBUTE_ERROR_CODE_HEADER_LENGTH + errorPhraseLength;
         attributeValueLengthPadded = STUN_ALIGN_SIZE_TO_WORD( attributeValueLength );
-    }
 
-    if( ( result == STUN_RESULT_OK ) &&
-        ( pCtx->pStart != NULL ) )
-    {
-        if( STUN_REMAINING_LENGTH( pCtx ) < ( size_t ) STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLengthPadded ) )
+        if( pCtx->pStart != NULL )
         {
-            result = STUN_RESULT_OUT_OF_MEMORY;
+            if( STUN_REMAINING_LENGTH( pCtx ) < ( size_t ) STUN_ATTRIBUTE_TOTAL_LENGTH( attributeValueLengthPadded ) )
+            {
+                result = STUN_RESULT_OUT_OF_MEMORY;
+            }
         }
     }
 

--- a/source/stun_serializer.c
+++ b/source/stun_serializer.c
@@ -326,8 +326,8 @@ StunResult_t StunSerializer_Init( StunContext_t * pCtx,
 
     if( ( pCtx == NULL ) ||
         ( pHeader == NULL ) ||
-        ( ( pBuffer != NULL ) &&
-          ( bufferLength < STUN_HEADER_LENGTH ) ) )
+        ( ( pBuffer != NULL ) && ( bufferLength < STUN_HEADER_LENGTH ) ) ||
+        ( ( pCtx->pStart != NULL ) && ( pHeader->pTransactionId == NULL ) ) )
     {
         result = STUN_RESULT_BAD_PARAM;
     }
@@ -343,31 +343,22 @@ StunResult_t StunSerializer_Init( StunContext_t * pCtx,
 
         if( pCtx->pStart != NULL )
         {
-            if( pHeader->pTransactionId == NULL )
-            {
-                result = STUN_RESULT_BAD_PARAM;
-            }
-            else
-            {
-                STUN_WRITE_UINT16( &( pCtx->pStart[ pCtx->currentIndex ] ),
-                                   pHeader->messageType );
+            STUN_WRITE_UINT16( &( pCtx->pStart[ pCtx->currentIndex ] ),
+                               pHeader->messageType );
 
-                /* Message length is updated in finalize. */
-                STUN_WRITE_UINT16( &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_MESSAGE_LENGTH_OFFSET ] ),
-                                   0 );
+            /* Message length is updated in finalize. */
+            STUN_WRITE_UINT16( &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_MESSAGE_LENGTH_OFFSET ] ),
+                               0 );
 
-                STUN_WRITE_UINT32( &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_MAGIC_COOKIE_OFFSET ] ),
-                                   STUN_HEADER_MAGIC_COOKIE );
+            STUN_WRITE_UINT32( &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_MAGIC_COOKIE_OFFSET ] ),
+                               STUN_HEADER_MAGIC_COOKIE );
 
-                memcpy( ( void * ) &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_TRANSACTION_ID_OFFSET ] ),
-                        ( const void * ) &( pHeader->pTransactionId[ 0 ] ),
-                        STUN_HEADER_TRANSACTION_ID_LENGTH );
-            }
+            memcpy( ( void * ) &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_TRANSACTION_ID_OFFSET ] ),
+                    ( const void * ) &( pHeader->pTransactionId[ 0 ] ),
+                    STUN_HEADER_TRANSACTION_ID_LENGTH );
+
         }
-    }
 
-    if( result == STUN_RESULT_OK )
-    {
         pCtx->currentIndex += STUN_HEADER_LENGTH;
     }
 
@@ -388,12 +379,7 @@ StunResult_t StunSerializer_AddAttributeErrorCode( StunContext_t * pCtx,
 
     if( ( pCtx == NULL ) ||
         ( pErrorPhrase == NULL ) ||
-        ( errorPhraseLength == 0 ) )
-    {
-        result = STUN_RESULT_BAD_PARAM;
-    }
-
-    if( ( result == STUN_RESULT_OK ) &&
+        ( errorPhraseLength == 0 ) ||
         ( errorPhraseLength > ( STUN_ATTRIBUTE_ERROR_CODE_VALUE_MAX_LENGTH - STUN_ATTRIBUTE_ERROR_CODE_HEADER_LENGTH ) ) )
     {
         result = STUN_RESULT_BAD_PARAM;

--- a/source/stun_serializer.c
+++ b/source/stun_serializer.c
@@ -87,7 +87,8 @@ static StunResult_t AddAttributeBuffer( StunContext_t * pCtx,
 
     if( ( pCtx == NULL ) ||
         ( pAttributeValueBuffer == NULL ) ||
-        ( attributeValueBufferLength == 0 ) )
+        ( attributeValueBufferLength == 0 ) ||
+        ( attributeValueBufferLength > STUN_ATTRIBUTE_VALUE_MAX_LENGTH ) )
     {
         result = STUN_RESULT_BAD_PARAM;
     }
@@ -371,8 +372,8 @@ StunResult_t StunSerializer_AddAttributeErrorCode( StunContext_t * pCtx,
                                                    uint16_t errorPhraseLength )
 {
     StunResult_t result = STUN_RESULT_OK;
-    uint16_t attributeValueLength = STUN_ATTRIBUTE_ERROR_CODE_HEADER_LENGTH + errorPhraseLength;
-    uint16_t attributeValueLengthPadded = STUN_ALIGN_SIZE_TO_WORD( attributeValueLength );
+    uint16_t attributeValueLength;
+    uint16_t attributeValueLengthPadded;
     uint16_t reserved = 0x0;
 
     if( ( pCtx == NULL ) ||
@@ -380,6 +381,18 @@ StunResult_t StunSerializer_AddAttributeErrorCode( StunContext_t * pCtx,
         ( errorPhraseLength == 0 ) )
     {
         result = STUN_RESULT_BAD_PARAM;
+    }
+
+    if( ( result == STUN_RESULT_OK ) &&
+        ( errorPhraseLength > ( STUN_ATTRIBUTE_ERROR_CODE_VALUE_MAX_LENGTH - STUN_ATTRIBUTE_ERROR_CODE_HEADER_LENGTH ) ) )
+    {
+        result = STUN_RESULT_BAD_PARAM;
+    }
+
+    if( result == STUN_RESULT_OK )
+    {
+        attributeValueLength = STUN_ATTRIBUTE_ERROR_CODE_HEADER_LENGTH + errorPhraseLength;
+        attributeValueLengthPadded = STUN_ALIGN_SIZE_TO_WORD( attributeValueLength );
     }
 
     if( ( result == STUN_RESULT_OK ) &&

--- a/source/stun_serializer.c
+++ b/source/stun_serializer.c
@@ -343,21 +343,31 @@ StunResult_t StunSerializer_Init( StunContext_t * pCtx,
 
         if( pCtx->pStart != NULL )
         {
-            STUN_WRITE_UINT16( &( pCtx->pStart[ pCtx->currentIndex ] ),
-                               pHeader->messageType );
+            if( pHeader->pTransactionId == NULL )
+            {
+                result = STUN_RESULT_BAD_PARAM;
+            }
+            else
+            {
+                STUN_WRITE_UINT16( &( pCtx->pStart[ pCtx->currentIndex ] ),
+                                   pHeader->messageType );
 
-            /* Message length is updated in finalize. */
-            STUN_WRITE_UINT16( &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_MESSAGE_LENGTH_OFFSET ] ),
-                               0 );
+                /* Message length is updated in finalize. */
+                STUN_WRITE_UINT16( &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_MESSAGE_LENGTH_OFFSET ] ),
+                                   0 );
 
-            STUN_WRITE_UINT32( &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_MAGIC_COOKIE_OFFSET ] ),
-                               STUN_HEADER_MAGIC_COOKIE );
+                STUN_WRITE_UINT32( &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_MAGIC_COOKIE_OFFSET ] ),
+                                   STUN_HEADER_MAGIC_COOKIE );
 
-            memcpy( ( void * ) &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_TRANSACTION_ID_OFFSET ] ),
-                    ( const void * ) &( pHeader->pTransactionId[ 0 ] ),
-                    STUN_HEADER_TRANSACTION_ID_LENGTH );
+                memcpy( ( void * ) &( pCtx->pStart[ pCtx->currentIndex + STUN_HEADER_TRANSACTION_ID_OFFSET ] ),
+                        ( const void * ) &( pHeader->pTransactionId[ 0 ] ),
+                        STUN_HEADER_TRANSACTION_ID_LENGTH );
+            }
         }
+    }
 
+    if( result == STUN_RESULT_OK )
+    {
         pCtx->currentIndex += STUN_HEADER_LENGTH;
     }
 

--- a/test/unit-test/stun_deserializer/stun_deserializer_utest.c
+++ b/test/unit-test/stun_deserializer/stun_deserializer_utest.c
@@ -3088,3 +3088,466 @@ void test_StunDeserializer_GetNextAttribute_MalformedChangeRequest( void )
 }
 
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_ParseAttributeAddress (RESPONSE_ADDRESS Type) in happy path.
+ */
+void test_StunDeserializer_ParseAttributeAddress_ResponseAddress_HappyPath( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    StunAttributeAddress_t parsedAddress = { 0 };
+    uint8_t expectedAddress[] = { 0x7F, 0x00, 0x00, 0x01 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x0C (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x0C,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = RESPONSE-ADDRESS (0x0002), Attribute Length = 8. */
+        0x00, 0x02, 0x00, 0x08,
+        /* Address family = IPv4, Port = 0x1234, IP Address = 0x7F000001 (127.0.0.1). */
+        0x00, 0x01, 0x12, 0x34, 0x7F, 0x00, 0x00, 0x01,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_RESPONSE_ADDRESS,
+                       attribute.attributeType );
+
+    result = StunDeserializer_ParseAttributeAddress( &( ctx ),
+                                                     &( attribute ),
+                                                     &( parsedAddress ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ADDRESS_IPv4,
+                       parsedAddress.family );
+    TEST_ASSERT_EQUAL( 0x1234,
+                       parsedAddress.port );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedAddress[ 0 ] ),
+                                   &( parsedAddress.address[ 0 ] ),
+                                   4 );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_ParseAttributeAddress (SOURCE_ADDRESS Type) in happy path.
+ */
+void test_StunDeserializer_ParseAttributeAddress_SourceAddress_HappyPath( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    StunAttributeAddress_t parsedAddress = { 0 };
+    uint8_t expectedAddress[] = { 0xC0, 0xA8, 0x01, 0x01 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x0C (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x0C,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = SOURCE-ADDRESS (0x0004), Attribute Length = 8. */
+        0x00, 0x04, 0x00, 0x08,
+        /* Address family = IPv4, Port = 0x5678, IP Address = 0xC0A80101 (192.168.1.1). */
+        0x00, 0x01, 0x56, 0x78, 0xC0, 0xA8, 0x01, 0x01,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_SOURCE_ADDRESS,
+                       attribute.attributeType );
+
+    result = StunDeserializer_ParseAttributeAddress( &( ctx ),
+                                                     &( attribute ),
+                                                     &( parsedAddress ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ADDRESS_IPv4,
+                       parsedAddress.family );
+    TEST_ASSERT_EQUAL( 0x5678,
+                       parsedAddress.port );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedAddress[ 0 ] ),
+                                   &( parsedAddress.address[ 0 ] ),
+                                   4 );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_ParseAttributeAddress (CHANGED_ADDRESS Type) in happy path.
+ */
+void test_StunDeserializer_ParseAttributeAddress_ChangedAddress_HappyPath( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    StunAttributeAddress_t parsedAddress = { 0 };
+    uint8_t expectedAddress[] = { 0x08, 0x08, 0x08, 0x08 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x0C (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x0C,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = CHANGED-ADDRESS (0x0005), Attribute Length = 8. */
+        0x00, 0x05, 0x00, 0x08,
+        /* Address family = IPv4, Port = 0x0050, IP Address = 0x08080808 (8.8.8.8). */
+        0x00, 0x01, 0x00, 0x50, 0x08, 0x08, 0x08, 0x08,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_CHANGED_ADDRESS,
+                       attribute.attributeType );
+
+    result = StunDeserializer_ParseAttributeAddress( &( ctx ),
+                                                     &( attribute ),
+                                                     &( parsedAddress ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ADDRESS_IPv4,
+                       parsedAddress.family );
+    TEST_ASSERT_EQUAL( 0x0050,
+                       parsedAddress.port );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedAddress[ 0 ] ),
+                                   &( parsedAddress.address[ 0 ] ),
+                                   4 );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_ParseAttributeAddress (REFLECTED_FROM Type) in happy path.
+ */
+void test_StunDeserializer_ParseAttributeAddress_ReflectedFrom_HappyPath( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    StunAttributeAddress_t parsedAddress = { 0 };
+    uint8_t expectedAddress[] = { 0xAC, 0x10, 0x0A, 0x01 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x0C (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x0C,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = REFLECTED-FROM (0x000B), Attribute Length = 8. */
+        0x00, 0x0B, 0x00, 0x08,
+        /* Address family = IPv4, Port = 0x1A0A, IP Address = 0xAC100A01 (172.16.10.1). */
+        0x00, 0x01, 0x1A, 0x0A, 0xAC, 0x10, 0x0A, 0x01,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_REFLECTED_FROM,
+                       attribute.attributeType );
+
+    result = StunDeserializer_ParseAttributeAddress( &( ctx ),
+                                                     &( attribute ),
+                                                     &( parsedAddress ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ADDRESS_IPv4,
+                       parsedAddress.family );
+    TEST_ASSERT_EQUAL( 0x1A0A,
+                       parsedAddress.port );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( expectedAddress[ 0 ] ),
+                                   &( parsedAddress.address[ 0 ] ),
+                                   4 );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_GetNextAttribute with malformed RESPONSE_ADDRESS attribute.
+ */
+void test_StunDeserializer_GetNextAttribute_MalformedResponseAddress( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x14 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x14,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = RESPONSE-ADDRESS (0x0002), Attribute Length = 16 (set invalid intentionally). */
+        0x00, 0x02, 0x00, 0x10,
+        /* Address family = IPv4, Port = 0x1234, IP Address = 0x7F000001 (127.0.0.1)
+         * and additional 8 invalid bytes. */
+        0x00, 0x01, 0x12, 0x34, 0x7F, 0x00, 0x00, 0x01,
+        0x80, 0x28, 0x00, 0x04, 0x07, 0x8E, 0x38, 0x3F,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_INVALID_ATTRIBUTE,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_RESPONSE_ADDRESS,
+                       attribute.attributeType );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_GetNextAttribute with malformed SOURCE_ADDRESS attribute.
+ */
+void test_StunDeserializer_GetNextAttribute_MalformedSourceAddress( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x14 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x14,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = SOURCE-ADDRESS (0x0004), Attribute Length = 16 (set invalid intentionally). */
+        0x00, 0x04, 0x00, 0x10,
+        /* Address family = IPv4, Port = 0x5678, IP Address = 0xC0A80101 (192.168.1.1)
+         * and additional 8 invalid bytes. */
+        0x00, 0x01, 0x56, 0x78, 0xC0, 0xA8, 0x01, 0x01,
+        0x00, 0x04, 0x00, 0x10, 0xC0, 0xA8, 0x01, 0x01,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_INVALID_ATTRIBUTE,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_SOURCE_ADDRESS,
+                       attribute.attributeType );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_GetNextAttribute with malformed CHANGED_ADDRESS attribute.
+ */
+void test_StunDeserializer_GetNextAttribute_MalformedChangedAddress( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x14 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x14,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = CHANGED-ADDRESS (0x0005), Attribute Length = 16 (set invalid intentionally). */
+        0x00, 0x05, 0x00, 0x10,
+        /* Address family = IPv4, Port = 0x0050, IP Address = 0x08080808 (8.8.8.8)
+         * and additional 8 invalid bytes. */
+        0x00, 0x01, 0x00, 0x50, 0x08, 0x08, 0x08, 0x08,
+        0x00, 0x05, 0x00, 0x10, 0x08, 0x08, 0x08, 0x08,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_INVALID_ATTRIBUTE,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_CHANGED_ADDRESS,
+                       attribute.attributeType );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_GetNextAttribute with malformed REFLECTED_FROM attribute.
+ */
+void test_StunDeserializer_GetNextAttribute_MalformedReflectedFrom( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x14 (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x14,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = REFLECTED-FROM (0x000B), Attribute Length = 16 (set invalid intentionally). */
+        0x00, 0x0B, 0x00, 0x10,
+        /* Address family = IPv4, Port = 0x1A0A, IP Address = 0xAC100A01 (172.16.10.1)
+         * and additional 8 invalid bytes. */
+        0x00, 0x01, 0x1A, 0x0A, 0xAC, 0x10, 0x0A, 0x01,
+        0x00, 0x0B, 0x00, 0x10, 0xAC, 0x10, 0x0A, 0x01,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_INVALID_ATTRIBUTE,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_REFLECTED_FROM,
+                       attribute.attributeType );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunDeserializer_GetNextAttribute with USERNAME attribute.
+ */
+void test_StunDeserializer_GetNextAttribute_Username_HappyPath( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    StunAttribute_t attribute = { 0 };
+    uint8_t serializedMessage[] =
+    {
+        /* Message Type = STUN Binding Request, Message Length = 0x0C (excluding 20 bytes header). */
+        0x00, 0x01, 0x00, 0x0C,
+        /* Magic cookie. */
+        0x21, 0x12, 0xA4, 0x42,
+        /* Transaction ID. */
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5,
+        /* Attribute type = USERNAME (0x0006), Attribute Length = 8. */
+        0x00, 0x06, 0x00, 0x08,
+        /* Username = "testuser". */
+        0x74, 0x65, 0x73, 0x74,
+        0x75, 0x73, 0x65, 0x72,
+    };
+    size_t serializedMessageLength = sizeof( serializedMessage );
+
+    result = StunDeserializer_Init( &( ctx ),
+                                    &( serializedMessage[ 0 ] ),
+                                    serializedMessageLength,
+                                    &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunDeserializer_GetNextAttribute( &( ctx ),
+                                                &( attribute ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( STUN_ATTRIBUTE_TYPE_USERNAME,
+                       attribute.attributeType );
+    TEST_ASSERT_EQUAL( 8,
+                       attribute.attributeValueLength );
+    TEST_ASSERT_NOT_NULL( attribute.pAttributeValue );
+}
+
+/*-----------------------------------------------------------*/

--- a/test/unit-test/stun_serializer/stun_serializer_utest.c
+++ b/test/unit-test/stun_serializer/stun_serializer_utest.c
@@ -144,6 +144,10 @@ void test_StunSerializer_Init_BadParams( void )
     StunContext_t ctx = { 0 };
     StunResult_t result;
     StunHeader_t header = { 0 };
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
+    {
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
 
     result = StunSerializer_Init( NULL,
                                   pStunMessageBuffer,
@@ -168,7 +172,29 @@ void test_StunSerializer_Init_BadParams( void )
 
     TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
                        result );
+
+    header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
+    header.pTransactionId = &( transactionId[ 0 ] );
+
+    result = StunSerializer_Init( &( ctx ),
+                                  pStunMessageBuffer,
+                                  STUN_MESSAGE_BUFFER_LENGTH,
+                                  &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    header.pTransactionId = NULL;
+    result = StunSerializer_Init( &( ctx ),
+                                  pStunMessageBuffer,
+                                  STUN_MESSAGE_BUFFER_LENGTH,
+                                  &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
+                       result );
 }
+
+
 
 /*-----------------------------------------------------------*/
 
@@ -435,6 +461,43 @@ void test_StunSerializer_AddAttributeErrorCode_OutOfMemory( void )
                                                    errorPhraseLength );
 
     TEST_ASSERT_EQUAL( STUN_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunSerializer_AddAttributeErrorCode with error phrase length exceeding max.
+ */
+void test_StunSerializer_AddAttributeErrorCode_ExceedsMaxLength( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint16_t errorCode = 600;
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
+    {
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
+    uint8_t largeBuffer[ STUN_ATTRIBUTE_VALUE_MAX_LENGTH ];
+
+    header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
+    header.pTransactionId = &( transactionId[ 0 ] );
+
+    result = StunSerializer_Init( &( ctx ),
+                                  pStunMessageBuffer,
+                                  STUN_MESSAGE_BUFFER_LENGTH,
+                                  &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunSerializer_AddAttributeErrorCode( &( ctx ),
+                                                   errorCode,
+                                                   &( largeBuffer[ 0 ] ),
+                                                   STUN_ATTRIBUTE_VALUE_MAX_LENGTH );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
                        result );
 }
 
@@ -2250,6 +2313,41 @@ void test_StunSerializer_AddAttributeUsername_BufferNull( void )
     /* We should be able to get the correct length of the STUN message. */
     TEST_ASSERT_EQUAL( expectedStunMessageLength,
                        stunMessageLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate StunSerializer_AddAttributeUsername with buffer length exceeding max.
+ */
+void test_StunSerializer_AddAttributeUsername_ExceedsMaxLength( void )
+{
+    StunContext_t ctx = { 0 };
+    StunResult_t result;
+    StunHeader_t header = { 0 };
+    uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ] =
+    {
+        0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xAB, 0xCD, 0xEF, 0xA5
+    };
+    uint8_t largeBuffer[ STUN_ATTRIBUTE_VALUE_MAX_LENGTH + 1 ];
+
+    header.messageType = STUN_MESSAGE_TYPE_BINDING_REQUEST;
+    header.pTransactionId = &( transactionId[ 0 ] );
+
+    result = StunSerializer_Init( &( ctx ),
+                                  pStunMessageBuffer,
+                                  STUN_MESSAGE_BUFFER_LENGTH,
+                                  &( header ) );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_OK,
+                       result );
+
+    result = StunSerializer_AddAttributeUsername( &( ctx ),
+                                                  &( largeBuffer[ 0 ] ),
+                                                  STUN_ATTRIBUTE_VALUE_MAX_LENGTH + 1 );
+
+    TEST_ASSERT_EQUAL( STUN_RESULT_BAD_PARAM,
+                       result );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix buffer overflow in address parsing 
- Enforce consistent attribute size limits
- Fix NULL pointer dereference in StunSerializer_Init
- Simplify overflow checks 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
